### PR TITLE
Updating Action name

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const params = context.repo({path: '.github/config.yml'})
 
 - [create-an-issue](https://github.com/JasonEtco/create-an-issue)
 - [deploy-lambda-action](https://github.com/lannonbr/deploy-lambda-action)
-- [repo-push-check-action](https://github.com/lannonbr/repo-push-check-action)
+- [repo-permission-check-action](https://github.com/lannonbr/repo-permission-check-action)
 
 ## FAQ
 


### PR DESCRIPTION
I extended repo-push-check-action to have a defined argument when you use the action in a workflow and with such, I slightly changed the name since it now is more generalized.