### PR TITLE
Remove @octokit/webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,33 +78,6 @@
         "url-template": "^2.0.8"
       }
     },
-    "@octokit/webhooks": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-5.0.2.tgz",
-      "integrity": "sha512-htxI5cNiaEOlJbero6akw8bVZm3maN7LtCZbczxJQko3NvQqiROmzryE39+FnaoaHkQr6IAOx2JnPBZlkPHnVQ==",
-      "dev": true,
-      "requires": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "debug": "^4.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
-      }
-    },
     "@types/dotenv": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.0.tgz",
@@ -1048,12 +1021,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "type": "git",
     "url": "git+https://github.com/JasonEtco/actions-toolkit.git"
   },
-  "keywords": [],
+  "keywords": [
+    "github",
+    "github actions",
+    "typescript",
+    "github api"
+  ],
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "bugs": {
@@ -23,7 +28,6 @@
   },
   "homepage": "https://github.com/JasonEtco/actions-toolkit#readme",
   "devDependencies": {
-    "@octokit/webhooks": "^5.0.2",
     "@types/dotenv": "^6.1.0",
     "@types/execa": "^0.9.0",
     "@types/jest": "^23.3.10",


### PR DESCRIPTION
This PR removes `@octokit/webhooks` from the devDependencies. Really not sure why it was there in the first place 🤔 I've also added some keywords to the `package.json`, because why not.