### PR TITLE
Defaults for store file path

### DIFF
--- a/bin/template/Dockerfile
+++ b/bin/template/Dockerfile
@@ -13,7 +13,9 @@ FROM node:slim
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"="Your action name"
 LABEL "com.github.actions.description"="A description of your action"
+# Here all of the available icons: https://feathericons.com/
 LABEL "com.github.actions.icon"="play"
+# And all of the available colors: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#label
 LABEL "com.github.actions.color"="gray-dark"
 
 # Copy the package.json and package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A toolkit for building GitHub Actions in Node.js",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -35,8 +35,8 @@ export class Store {
   private cache: Cache
 
   constructor (workflow: string, workspace: string) {
-    this.file = `.${workflow}-cache`
-    this.cache = load(this.file, path.resolve(workspace))
+    this.file = `.${workflow || 'workflow'}-cache`
+    this.cache = load(this.file, path.resolve(workspace || process.cwd()))
 
     this.get = this.cache.getKey.bind(this.cache)
     this.set = this.cache.setKey.bind(this.cache)


### PR DESCRIPTION
Tiny fix for yesterday's addition of #30 - this PR adds some default path values if `GITHUB_WORKSPACE` and `GITHUB_WORKFLOW` aren't defined. This can't happen in actual Actions, but can happen when running an Action locally if not all environment variables have been set.

I've also added some comments to the template's Dockerfile.