### PR TITLE
Allow only a list of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This will create a new folder `my-cool-action` with the following files:
 
 ## API
 
+* [The Toolkit class](#toolkit)
 * [Authenticated GitHub API client](#toolsgithub)
 * [Parsing arguments](#toolsarguments)
 * [Reading files](#toolsgetfilepath-encoding--utf8)
@@ -54,6 +55,18 @@ This will create a new folder `my-cool-action` with the following files:
 * [In-repo configuration](#toolsconfigfilename)
 * [Pass information to another action](#toolsstore)
 * [Inspect the webhook event payload](#toolscontext)
+
+### Toolkit options
+
+#### only (optional)
+
+An optional array of [events that this action works with](https://developer.github.com/actions/creating-workflows/workflow-configuration-options/#events-supported-in-workflow-files). If omitted, the action will run for any event - if present, the action will exit with a failing status code for any event that is not allowed.
+
+```js
+const tools = new Toolkit({
+  only: ['issues', 'pull_requests']
+})
+```
 
 ### tools.github
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,29 @@ This will create a new folder `my-cool-action` with the following files:
 
 ### Toolkit options
 
-#### only (optional)
+#### event (optional)
 
-An optional array of [events that this action works with](https://developer.github.com/actions/creating-workflows/workflow-configuration-options/#events-supported-in-workflow-files). If omitted, the action will run for any event - if present, the action will exit with a failing status code for any event that is not allowed.
+An optional list of [events that this action works with](https://developer.github.com/actions/creating-workflows/workflow-configuration-options/#events-supported-in-workflow-files). If omitted, the action will run for any event - if present, the action will exit with a failing status code for any event that is not allowed.
 
 ```js
 const tools = new Toolkit({
-  only: ['issues', 'pull_requests']
+  event: ['issues', 'pull_requests']
+})
+```
+
+You can also pass a single string:
+
+```js
+const tools = new Toolkit({
+  event: 'issues'
+})
+```
+
+And/or strings that include an action (what actually happened to trigger this event) for even more specificity:
+
+```js
+const tools = new Toolkit({
+  event: ['issues.created']
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This will create a new folder `my-cool-action` with the following files:
 
 ## API
 
-* [The Toolkit class](#toolkit)
+* [The Toolkit class](#toolkit-options)
 * [Authenticated GitHub API client](#toolsgithub)
 * [Parsing arguments](#toolsarguments)
 * [Reading files](#toolsgetfilepath-encoding--utf8)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A toolkit for building GitHub Actions in Node.js",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { GitHub } from './github'
 import { Store } from './store'
 
 export interface ToolkitOptions {
-  event?: string | string[]
+  event?: string | string[],
+  logger?: Console | any
 }
 
 export class Toolkit {
@@ -48,8 +49,11 @@ export class Toolkit {
 
   public opts: ToolkitOptions
 
+  public log: Console | any
+
   constructor (opts: ToolkitOptions = {}) {
     this.opts = opts
+    this.log = opts.logger || console
 
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
@@ -163,8 +167,7 @@ export class Toolkit {
 
     if (failed) {
       const actionStr = this.context.payload.action ? `.${this.context.payload.action}` : ''
-      // tslint:disable-next-line:no-console
-      console.error(`Event ${this.context.event}${actionStr} is not supported by this action.`)
+      this.log.error(`Event \`${this.context.event}${actionStr}\` is not supported by this action.`)
       process.exit(1)
     }
   }
@@ -192,9 +195,7 @@ export class Toolkit {
       // This isn't being run inside of a GitHub Action environment!
       const list = requiredButMissing.map(key => `- ${key}`).join('\n')
       const warning = `There are environment variables missing from this runtime, but would be present on GitHub.\n${list}`
-
-      // tslint:disable-next-line:no-console
-      console.warn(warning)
+      this.log.warn(warning)
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,10 @@ import Context from './context'
 import { GitHub } from './github'
 import { Store } from './store'
 
+export interface ToolkitOptions {
+  only?: string[]
+}
+
 export class Toolkit {
   public context: Context
 
@@ -47,7 +51,10 @@ export class Toolkit {
    */
   public github: GitHub
 
-  constructor () {
+  public opts?: ToolkitOptions
+
+  constructor (opts?: ToolkitOptions) {
+    this.opts = opts
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
 
@@ -57,6 +64,12 @@ export class Toolkit {
     this.github = new GitHub(this.token)
     this.arguments = minimist(process.argv.slice(2))
     this.store = new Store(this.context.workflow, this.workspace)
+
+    if (opts && Array.isArray(opts.only) && !opts.only.includes(this.context.event)) {
+      // tslint:disable-next-line:no-console
+      console.error(`Event ${this.context.event} is not supported by this action.`)
+      process.exit(1)
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export class Toolkit {
 
   constructor (opts?: ToolkitOptions) {
     this.opts = opts
+
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,6 @@ export class Toolkit {
   public store: Store
 
   /**
-   * A warning string that is memoized if there are missing environment variables
-   */
-  public warning: string | undefined
-
-  /**
    * Path to a clone of the repository
    */
   public workspace: string
@@ -175,7 +170,6 @@ export class Toolkit {
 
       // tslint:disable-next-line:no-console
       console.warn(warning)
-      this.warning = warning
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,10 +151,10 @@ export class Toolkit {
     const [eventName, action] = event.split('.')
 
     if (action) {
-      return this.context.payload.action !== action
+      return eventName === this.context.event && this.context.payload.action === action
     }
 
-    return eventName !== this.context.event
+    return eventName === this.context.event
   }
 
   private checkAllowedEvents () {
@@ -162,8 +162,8 @@ export class Toolkit {
     if (!event) return
 
     const failed = Array.isArray(event)
-      ? event.some(e => this.eventIsAllowed(e))
-      : this.eventIsAllowed(event)
+      ? !event.some(e => this.eventIsAllowed(e))
+      : !this.eventIsAllowed(event)
 
     if (failed) {
       const actionStr = this.context.payload.action ? `.${this.context.payload.action}` : ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,11 +161,11 @@ export class Toolkit {
     const { event } = this.opts
     if (!event) return
 
-    const failed = Array.isArray(event)
-      ? !event.some(e => this.eventIsAllowed(e))
-      : !this.eventIsAllowed(event)
+    const passed = Array.isArray(event)
+      ? event.some(e => this.eventIsAllowed(e))
+      : this.eventIsAllowed(event)
 
-    if (failed) {
+    if (!passed) {
       const actionStr = this.context.payload.action ? `.${this.context.payload.action}` : ''
       this.log.error(`Event \`${this.context.event}${actionStr}\` is not supported by this action.`)
       process.exit(1)

--- a/tests/__snapshots__/context.test.ts.snap
+++ b/tests/__snapshots__/context.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Context .payload returns the payload object 1`] = `
 Object {
+  "action": "opened",
   "issue": Object {
     "number": 1,
   },

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -31,6 +31,46 @@ Object {
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
 
+exports[`Toolkit#constructor does not exit if the event is one of the allowed with an array of events 1`] = `
+Array [
+  Array [
+    "Event \`issues.opened\` is not supported by this action.",
+  ],
+]
+`;
+
+exports[`Toolkit#constructor exits if the event is not allowed with a single event 1`] = `
+Array [
+  Array [
+    "Event \`issues.opened\` is not supported by this action.",
+  ],
+]
+`;
+
+exports[`Toolkit#constructor exits if the event is not allowed with a single event with an action 1`] = `
+Array [
+  Array [
+    "Event \`issues\` is not supported by this action.",
+  ],
+]
+`;
+
+exports[`Toolkit#constructor exits if the event is not allowed with an array of events 1`] = `
+Array [
+  Array [
+    "Event \`issues.opened\` is not supported by this action.",
+  ],
+]
+`;
+
+exports[`Toolkit#constructor exits if the event is not allowed with an array of events with actions 1`] = `
+Array [
+  Array [
+    "Event \`issues\` is not supported by this action.",
+  ],
+]
+`;
+
 exports[`Toolkit#constructor logs the expected string with missing env vars 1`] = `
 Array [
   Array [

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolkit #constructor logs the expected string with missing env vars 1`] = `
-Array [
-  Array [
-    "There are environment variables missing from this runtime, but would be present on GitHub.
-- HOME",
-  ],
-]
-`;
-
 exports[`Toolkit #getFile gets the contents of a file 1`] = `"I'm writing this on a plane ✈️"`;
 
 exports[`Toolkit #getFile gets the contents of a file with custom encoding 1`] = `"SSdtIHdyaXRpbmcgdGhpcyBvbiBhIHBsYW5lIOKciO+4jw=="`;
@@ -39,3 +30,12 @@ Object {
 `;
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
+
+exports[`Toolkit#constructor logs the expected string with missing env vars 1`] = `
+Array [
+  Array [
+    "There are environment variables missing from this runtime, but would be present on GitHub.
+- HOME",
+  ],
+]
+`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -39,8 +39,3 @@ Object {
 `;
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
-
-exports[`Toolkit #warnForMissingEnvVars logs the expected string 1`] = `
-"There are environment variables missing from this runtime, but would be present on GitHub.
-- HOME"
-`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Toolkit #constructor logs the expected string with missing env vars 1`] = `
+Array [
+  Array [
+    "There are environment variables missing from this runtime, but would be present on GitHub.
+- HOME",
+  ],
+]
+`;
+
 exports[`Toolkit #getFile gets the contents of a file 1`] = `"I'm writing this on a plane ✈️"`;
 
 exports[`Toolkit #getFile gets the contents of a file with custom encoding 1`] = `"SSdtIHdyaXRpbmcgdGhpcyBvbiBhIHBsYW5lIOKciO+4jw=="`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -31,14 +31,6 @@ Object {
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
 
-exports[`Toolkit#constructor does not exit if the event is one of the allowed with an array of events 1`] = `
-Array [
-  Array [
-    "Event \`issues.opened\` is not supported by this action.",
-  ],
-]
-`;
-
 exports[`Toolkit#constructor exits if the event is not allowed with a single event 1`] = `
 Array [
   Array [
@@ -50,7 +42,7 @@ Array [
 exports[`Toolkit#constructor exits if the event is not allowed with a single event with an action 1`] = `
 Array [
   Array [
-    "Event \`issues\` is not supported by this action.",
+    "Event \`issues.opened\` is not supported by this action.",
   ],
 ]
 `;
@@ -66,7 +58,7 @@ Array [
 exports[`Toolkit#constructor exits if the event is not allowed with an array of events with actions 1`] = `
 Array [
   Array [
-    "Event \`issues\` is not supported by this action.",
+    "Event \`issues.opened\` is not supported by this action.",
   ],
 ]
 `;

--- a/tests/fixtures/issues.opened.json
+++ b/tests/fixtures/issues.opened.json
@@ -1,4 +1,5 @@
 {
+  "action": "opened",
   "repository": {
     "owner": {
       "login": "JasonEtco"

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -7,14 +7,12 @@ describe('Toolkit', () => {
   let logger: any
 
   beforeEach(() => {
-    toolkit = new Toolkit()
-    logger = console as any
     logger = {
       error: jest.fn(),
       log: jest.fn(),
       warn: jest.fn()
     }
-    console = logger
+    toolkit = new Toolkit({ logger })
   })
 
   describe('#github', () => {
@@ -95,9 +93,15 @@ describe('Toolkit', () => {
 })
 
 describe('Toolkit#constructor', () => {
+  let logger: any
   let exit: (code?: number) => never
 
   beforeEach(() => {
+    logger = {
+      error: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn()
+    }
     exit = global.process.exit
     const p = global.process as any
     p.exit = jest.fn()
@@ -105,47 +109,43 @@ describe('Toolkit#constructor', () => {
 
   it('exits if the event is not allowed with an array of events', () => {
     // tslint:disable-next-line:no-unused-expression
-    new Toolkit({ event: ['pull_request'] })
+    new Toolkit({ logger, event: ['pull_request'] })
     expect(process.exit).toHaveBeenCalledWith(1)
+    expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('does not exit if the event is one of the allowed with an array of events', () => {
     // tslint:disable-next-line:no-unused-expression
-    new Toolkit({ event: ['pull_request', 'issues'] })
+    new Toolkit({ logger, event: ['pull_request', 'issues'] })
     expect(process.exit).toHaveBeenCalledWith(1)
+    expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('exits if the event is not allowed with a single event', () => {
     // tslint:disable-next-line:no-unused-expression
-    new Toolkit({ event: 'pull_request' })
+    new Toolkit({ logger, event: 'pull_request' })
     expect(process.exit).toHaveBeenCalledWith(1)
+    expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('exits if the event is not allowed with an array of events with actions', () => {
     // tslint:disable-next-line:no-unused-expression
-    new Toolkit({ event: ['pull_request.opened'] })
+    new Toolkit({ logger, event: ['pull_request.opened'] })
     expect(process.exit).toHaveBeenCalledWith(1)
+    expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('exits if the event is not allowed with a single event with an action', () => {
     // tslint:disable-next-line:no-unused-expression
-    new Toolkit({ event: 'pull_request.opened' })
+    new Toolkit({ logger, event: 'pull_request.opened' })
     expect(process.exit).toHaveBeenCalledWith(1)
+    expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('logs the expected string with missing env vars', () => {
-    let logger = console as any
-    logger = {
-      error: jest.fn(),
-      log: jest.fn(),
-      warn: jest.fn()
-    }
-    console = logger
-    logger.warn = jest.fn()
-
     delete process.env.HOME
     // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
-    new Toolkit() // tslint:disable-line:no-unused-expression
+    new Toolkit({ logger }) // tslint:disable-line:no-unused-expression
     expect(logger.warn.mock.calls).toMatchSnapshot()
   })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -17,41 +17,6 @@ describe('Toolkit', () => {
     console = logger
   })
 
-  describe('#constructor', () => {
-    let exit: (code?: number) => never
-
-    beforeEach(() => {
-      exit = global.process.exit
-      const p = global.process as any
-      p.exit = jest.fn()
-    })
-
-    it('exits if the event is not allowed with an array of eventts', () => {
-      // tslint:disable-next-line:no-unused-expression
-      new Toolkit({ event: ['issues'] })
-      expect(process.exit).toHaveBeenCalledWith(1)
-    })
-
-    it('exits if the event is not allowed', () => {
-      // tslint:disable-next-line:no-unused-expression
-      new Toolkit({ event: 'issues' })
-      expect(process.exit).toHaveBeenCalledWith(1)
-    })
-
-    it('logs the expected string with missing env vars', () => {
-      logger.warn = jest.fn()
-
-      delete process.env.HOME
-      // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
-      new Toolkit() // tslint:disable-line:no-unused-expression
-      expect(logger.warn.mock.calls).toMatchSnapshot()
-    })
-
-    afterEach(() => {
-      global.process.exit = exit
-    })
-  })
-
   describe('#github', () => {
     it('returns a GitHub client', () => {
       expect(toolkit.github).toBeInstanceOf(Object)
@@ -126,5 +91,65 @@ describe('Toolkit', () => {
       const result = await toolkit.runInWorkspace('throw', undefined, { reject: false })
       expect(result).toMatchSnapshot()
     })
+  })
+})
+
+describe('Toolkit#constructor', () => {
+  let exit: (code?: number) => never
+
+  beforeEach(() => {
+    exit = global.process.exit
+    const p = global.process as any
+    p.exit = jest.fn()
+  })
+
+  it('exits if the event is not allowed with an array of events', () => {
+    // tslint:disable-next-line:no-unused-expression
+    new Toolkit({ event: ['pull_request'] })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('does not exit if the event is one of the allowed with an array of events', () => {
+    // tslint:disable-next-line:no-unused-expression
+    new Toolkit({ event: ['pull_request', 'issues'] })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('exits if the event is not allowed with a single event', () => {
+    // tslint:disable-next-line:no-unused-expression
+    new Toolkit({ event: 'pull_request' })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('exits if the event is not allowed with an array of events with actions', () => {
+    // tslint:disable-next-line:no-unused-expression
+    new Toolkit({ event: ['pull_request.opened'] })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('exits if the event is not allowed with a single event with an action', () => {
+    // tslint:disable-next-line:no-unused-expression
+    new Toolkit({ event: 'pull_request.opened' })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('logs the expected string with missing env vars', () => {
+    let logger = console as any
+    logger = {
+      error: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn()
+    }
+    console = logger
+    logger.warn = jest.fn()
+
+    delete process.env.HOME
+    // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
+    new Toolkit() // tslint:disable-line:no-unused-expression
+    expect(logger.warn.mock.calls).toMatchSnapshot()
+  })
+
+  afterEach(() => {
+    global.process.exit = exit
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -26,9 +26,15 @@ describe('Toolkit', () => {
       p.exit = jest.fn()
     })
 
+    it('exits if the event is not allowed with an array of eventts', () => {
+      // tslint:disable-next-line:no-unused-expression
+      new Toolkit({ event: ['issues'] })
+      expect(process.exit).toHaveBeenCalledWith(1)
+    })
+
     it('exits if the event is not allowed', () => {
       // tslint:disable-next-line:no-unused-expression
-      new Toolkit({ only: ['issues'] })
+      new Toolkit({ event: 'issues' })
       expect(process.exit).toHaveBeenCalledWith(1)
     })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -100,4 +100,24 @@ describe('Toolkit', () => {
       // tslint:enable:no-console
     })
   })
+
+  describe('#constructor', () => {
+    let exit: (code?: number) => never
+
+    beforeEach(() => {
+      exit = global.process.exit
+      const p = global.process as any
+      p.exit = jest.fn()
+    })
+
+    it('exits if the event is not allowed', () => {
+      // tslint:disable-next-line
+      new Toolkit({ only: ['issues'] })
+      expect(process.exit).toHaveBeenCalledWith(1)
+    })
+
+    afterEach(() => {
+      global.process.exit = exit
+    })
+  })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,9 +19,24 @@ describe('Toolkit', () => {
     })
 
     it('exits if the event is not allowed', () => {
-      // tslint:disable-next-line
+      // tslint:disable-next-line:no-unused-expression
       new Toolkit({ only: ['issues'] })
       expect(process.exit).toHaveBeenCalledWith(1)
+    })
+
+    it('logs the expected string with missing env vars', () => {
+      // tslint:disable:no-console
+      const before = console.warn
+      const c = console as any
+      c.warn = jest.fn()
+
+      delete process.env.HOME
+      // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
+      new Toolkit() // tslint:disable-line:no-unused-expression
+      expect(c.warn.mock.calls).toMatchSnapshot()
+
+      console.warn = before
+      // tslint:enable:no-console
     })
 
     afterEach(() => {
@@ -102,22 +117,6 @@ describe('Toolkit', () => {
     it('runs the command in the workspace with some options', async () => {
       const result = await toolkit.runInWorkspace('throw', undefined, { reject: false })
       expect(result).toMatchSnapshot()
-    })
-  })
-
-  describe('#warnForMissingEnvVars', () => {
-    it('logs the expected string', () => {
-      // tslint:disable:no-console
-      const before = console.warn
-      console.warn = f => f
-
-      delete process.env.HOME
-      // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
-      const twolkit = new Toolkit()
-      expect(twolkit.warning).toMatchSnapshot()
-
-      console.warn = before
-      // tslint:enable:no-console
     })
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -117,8 +117,8 @@ describe('Toolkit#constructor', () => {
   it('does not exit if the event is one of the allowed with an array of events', () => {
     // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: ['pull_request', 'issues'] })
-    expect(process.exit).toHaveBeenCalledWith(1)
-    expect(logger.error.mock.calls).toMatchSnapshot()
+    expect(process.exit).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
   })
 
   it('exits if the event is not allowed with a single event', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,6 +9,26 @@ describe('Toolkit', () => {
     toolkit = new Toolkit()
   })
 
+  describe('#constructor', () => {
+    let exit: (code?: number) => never
+
+    beforeEach(() => {
+      exit = global.process.exit
+      const p = global.process as any
+      p.exit = jest.fn()
+    })
+
+    it('exits if the event is not allowed', () => {
+      // tslint:disable-next-line
+      new Toolkit({ only: ['issues'] })
+      expect(process.exit).toHaveBeenCalledWith(1)
+    })
+
+    afterEach(() => {
+      global.process.exit = exit
+    })
+  })
+
   describe('#github', () => {
     it('returns a GitHub client', () => {
       expect(toolkit.github).toBeInstanceOf(Object)
@@ -98,26 +118,6 @@ describe('Toolkit', () => {
 
       console.warn = before
       // tslint:enable:no-console
-    })
-  })
-
-  describe('#constructor', () => {
-    let exit: (code?: number) => never
-
-    beforeEach(() => {
-      exit = global.process.exit
-      const p = global.process as any
-      p.exit = jest.fn()
-    })
-
-    it('exits if the event is not allowed', () => {
-      // tslint:disable-next-line
-      new Toolkit({ only: ['issues'] })
-      expect(process.exit).toHaveBeenCalledWith(1)
-    })
-
-    afterEach(() => {
-      global.process.exit = exit
     })
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,9 +4,17 @@ import { Toolkit } from '../src'
 
 describe('Toolkit', () => {
   let toolkit: Toolkit
+  let logger: any
 
   beforeEach(() => {
     toolkit = new Toolkit()
+    logger = console as any
+    logger = {
+      error: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn()
+    }
+    console = logger
   })
 
   describe('#constructor', () => {
@@ -25,18 +33,12 @@ describe('Toolkit', () => {
     })
 
     it('logs the expected string with missing env vars', () => {
-      // tslint:disable:no-console
-      const before = console.warn
-      const c = console as any
-      c.warn = jest.fn()
+      logger.warn = jest.fn()
 
       delete process.env.HOME
       // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
       new Toolkit() // tslint:disable-line:no-unused-expression
-      expect(c.warn.mock.calls).toMatchSnapshot()
-
-      console.warn = before
-      // tslint:enable:no-console
+      expect(logger.warn.mock.calls).toMatchSnapshot()
     })
 
     afterEach(() => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -144,7 +144,6 @@ describe('Toolkit#constructor', () => {
 
   it('logs the expected string with missing env vars', () => {
     delete process.env.HOME
-    // Toolkit, but number two. Ergo, twolkit. Open an issue if this isn't clear.
     new Toolkit({ logger }) // tslint:disable-line:no-unused-expression
     expect(logger.warn.mock.calls).toMatchSnapshot()
   })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,7 +3,7 @@ import path from 'path'
 Object.assign(process.env, {
   GITHUB_ACTION: 'my-action',
   GITHUB_ACTOR: 'JasonEtco',
-  GITHUB_EVENT_NAME: 'push',
+  GITHUB_EVENT_NAME: 'issues',
   GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'issues.opened.json'),
   GITHUB_REF: 'master',
   GITHUB_REPOSITORY: 'JasonEtco/actydoo',


### PR DESCRIPTION
This PR adds an object of options to the `Toolkit` constructor, currently with only one key:

```ts
export interface ToolkitOptions {
  event?: string | string[]
}
```

On `new Toolkit`, we check that the `process.env.GITHUB_EVENT` is in the array of `only` strings. If it is, we log an error and `exit(1)` to fail the action. You can omit this behavior entirely by just not passing a `only` property.

Read more in #36 for the motivation behind this addition.

Closes #36 

- [x] Docs
- [x] Is `only` the right name? How about `events`, `allowedEvents`?