### PR TITLE
Add methods to exit an action

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This will create a new folder `my-cool-action` with the following files:
 * [Run a CLI command](#toolsruninworkspacecommand-args-execaoptions)
 * [In-repo configuration](#toolsconfigfilename)
 * [Pass information to another action](#toolsstore)
+* [End the action's process](#toolsexit)
 * [Inspect the webhook event payload](#toolscontext)
 
 ### Toolkit options
@@ -182,6 +183,18 @@ The GitHub API token being used to authenticate requests.
 ### tools.workspace
 
 A path to a clone of the repository.
+
+<br>
+
+### tools.exit
+
+A collection of methods to end the action's process and tell GitHub what status to set (success, neutral or failure). Internally, these methods call `process.exit` with the [appropriate exit code](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses). You can pass an optional message to each one to be logged before exiting. This can be used like an early return:
+
+```js
+if (someCheck) tools.exit.neutral('No _action_ necessary!') 
+if (anError) tools.exit.failure('We failed!')
+tools.exit.success('We did it team!')
+```
 
 <br>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-toolkit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A toolkit for building GitHub Actions in Node.js",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,31 +1,25 @@
 // tslint:disable:no-console
 
+/**
+ * The code to exit an action with a "success" state
+ */
+export const SuccessCode = 0
+/**
+ * The code to exit an action with a "failure" state
+ */
+export const FailureCode = 1
+/**
+ * The code to exit an action with a "neutral" state
+ */
+export const NeutralCode = 78
+
 export class Exit {
-  /**
-   * The code to exit an action with a "success" state
-   */
-  public SuccessCode: number
-  /**
-   * The code to exit an action with a "failure" state
-   */
-  public FailureCode: number
-  /**
-   * The code to exit an action with a "neutral" state
-   */
-  public NeutralCode: number
-
-  constructor () {
-    this.SuccessCode = 0
-    this.FailureCode = 1
-    this.NeutralCode = 78
-  }
-
   /**
    * Stop the action with a "success" status
    */
   public success (message?: string) {
     if (message) console.log(message)
-    process.exit(this.SuccessCode)
+    process.exit(SuccessCode)
   }
 
   /**
@@ -33,7 +27,7 @@ export class Exit {
    */
   public neutral (message?: string) {
     if (message) console.log(message)
-    process.exit(this.NeutralCode)
+    process.exit(NeutralCode)
   }
 
   /**
@@ -41,6 +35,6 @@ export class Exit {
    */
   public failure (message?: string) {
     if (message) console.error(message)
-    process.exit(this.FailureCode)
+    process.exit(FailureCode)
   }
 }

--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,0 +1,46 @@
+// tslint:disable:no-console
+
+export class Exit {
+  /**
+   * The code to exit an action with a "success" state
+   */
+  public SuccessCode: number
+  /**
+   * The code to exit an action with a "failure" state
+   */
+  public FailureCode: number
+  /**
+   * The code to exit an action with a "neutral" state
+   */
+  public NeutralCode: number
+
+  constructor () {
+    this.SuccessCode = 0
+    this.FailureCode = 1
+    this.NeutralCode = 78
+  }
+
+  /**
+   * Stop the action with a "success" status
+   */
+  public success (message?: string) {
+    if (message) console.log(message)
+    process.exit(this.SuccessCode)
+  }
+
+  /**
+   * Stop the action with a "neutral" status
+   */
+  public neutral (message?: string) {
+    if (message) console.log(message)
+    process.exit(this.NeutralCode)
+  }
+
+  /**
+   * Stop the action with a "failed" status
+   */
+  public failure (message?: string) {
+    if (message) console.error(message)
+    process.exit(this.FailureCode)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,20 +4,9 @@ import yaml from 'js-yaml'
 import minimist, { ParsedArgs } from 'minimist'
 import path from 'path'
 import Context from './context'
+import { Exit } from './exit'
 import { GitHub } from './github'
 import { Store } from './store'
-/**
- * The code to exit an action with a "success" state
- */
-export const SuccessCode = 0
-/**
- * The code to exit an action with a "failure" state
- */
-export const FailureCode = 1
-/**
- * The code to exit an action with a "neutral" state
- */
-export const NeutralCode = 78
 
 export interface ToolkitOptions {
   only?: string[]
@@ -60,12 +49,18 @@ export class Toolkit {
 
   public opts?: ToolkitOptions
 
+  /**
+   * A collection of methods used to stop an action while it's being run
+   */
+  public exit: Exit
+
   constructor (opts?: ToolkitOptions) {
     this.opts = opts
 
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
 
+    this.exit = new Exit()
     this.context = new Context()
     this.workspace = process.env.GITHUB_WORKSPACE as string
     this.token = process.env.GITHUB_TOKEN as string

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,18 @@ import path from 'path'
 import Context from './context'
 import { GitHub } from './github'
 import { Store } from './store'
+/**
+ * The code to exit an action with a "success" state
+ */
+export const SuccessCode = 0
+/**
+ * The code to exit an action with a "failure" state
+ */
+export const FailureCode = 1
+/**
+ * The code to exit an action with a "neutral" state
+ */
+export const NeutralCode = 78
 
 export interface ToolkitOptions {
   only?: string[]

--- a/tests/exit.test.ts
+++ b/tests/exit.test.ts
@@ -1,0 +1,36 @@
+import { Exit, FailureCode, NeutralCode, SuccessCode } from '../src/exit'
+
+type methods = 'success' | 'neutral' | 'failure'
+type logs = 'log' | 'error'
+
+describe('Exit', () => {
+  let logger: any
+
+  beforeEach(() => {
+    logger = { error: jest.fn(), log: jest.fn() }
+    console = logger
+
+    const p = global.process as any
+    p.exit = jest.fn()
+  })
+
+  const exit = new Exit()
+
+  const tests = [
+    ['success', 'log', SuccessCode],
+    ['neutral', 'log', NeutralCode],
+    ['failure', 'error', FailureCode]
+  ]
+
+  describe.each(tests)('%s', (method, log, code) => {
+    it('exits with the expected code', () => {
+      exit[method as methods]()
+      expect(process.exit).toHaveBeenCalledWith(code)
+    })
+
+    it('logs the expected message', () => {
+      exit[method as methods]('hello')
+      expect(console[log as logs]).toHaveBeenCalledWith('hello')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds an `tools.exit` property with three methods, `success`, `neutral` and `failure`. They each take an optional message string:

```js
tools.exit.success()
tools.exit.failure('Something borked!')
```

- [x] Tests
- [x] Docs

Closes #35 