### PR TITLE
Use node testEnvironment in Jest instead of jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "signale": "^1.3.0"
   },
   "jest": {
+    "testEnvironment": "node",
     "setupFiles": [
       "<rootDir>/tests/setup.ts"
     ],


### PR DESCRIPTION
**Why?**

https://jestjs.io/docs/en/configuration#testenvironment-string

Jest defaults to running tests in a jsdom environment. Since actions-toolkit code is expected to run in a Node environment, updating this configuration parameter will more closely reflect the expected production environment.


**How?**

N/A

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)