### PR TITLE
add a way to return  a scoped logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,19 @@ export class Toolkit {
   }
 
   /**
+   * Create a scoped logger. Also an instance of [Signale](https://github.com/klaussinani/signale)
+   * This will prefix any logs with the name provided by @loggerScope
+   * @param loggerScope - Name of the scope
+   * @param logger - Provide a customized Signale logger
+   */
+  public createScopedLogger (loggerScope: string, logger?: Signale) {
+    if (!logger) logger = new Signale({ config: { underlineLabel: false } })
+    const loggerWithScope = logger.scope(loggerScope)
+    const fn = loggerWithScope.info.bind(loggerWithScope)
+    return Object.assign(fn, loggerWithScope)
+  }
+
+  /**
    * Returns true if this event is allowed
    */
   private eventIsAllowed (event: string) {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -71,3 +71,11 @@ Array [
   ],
 ]
 `;
+
+exports[`Toolkit#constructor sets a named logger 1`] = `
+Array [
+  Array [
+    "hi there from foo logger",
+  ],
+]
+`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -158,6 +158,15 @@ describe('Toolkit#constructor', () => {
     expect(logger.warn.mock.calls).toMatchSnapshot()
   })
 
+  it('sets a named logger', () => {
+    const tools = new Toolkit({ logger }) // tslint:disable-line:no-unused-expression
+    const fooLogger = {
+      success: jest.fn().mockImplementation(tools.createScopedLogger('foo').success)
+    }
+    fooLogger.success('hi there from foo logger')
+    expect(fooLogger.success.mock.calls).toMatchSnapshot()
+  })
+
   afterEach(() => {
     global.process.exit = exit
   })


### PR DESCRIPTION
Rather than having to create a full custom logger to get access to Signale's `scope`, this adds a public method that returns a scoped logger. This also defaults to the same options as the default logger.

**Why?**

When building the user-facing output for [Stale](https://github.com/probot/stale-action/blob/master/lib/stale.js#L219), @JasonEtco and I discussed some options to limit the amount of times you have to provide `prefix: '[Stale]'` on every message. It's possible to do this by providing a custom logger to the Toolkit, but I thought it could be nice to provide a public API to accomplish this.

**How?**

Signale has a build-in way to handle this using [Scopes](https://github.com/klaussinani/signale/#scoped-loggers), so this adds a new public method that returns the scoped logger. Any methods using that scoped logger will automatically be prefixed with the name you provide, while leaving the normal `tools.log` alone.

```javascript
const tools = new Toolkit()
const staleLogger = tools.createScopedLogger('Stale')
staleLogger.star(`Received ${tools.context.event}!`)
staleLogger.start('Stale action is booting up!')
staleLogger.pending('Retrieving Stale config from `.github/stale.yml`...')
tools.log.info('This will not be prefixed with Stale')
// Output:
// [Stale] › ★  star    Received repository_dispatch!
// [Stale] › ▶  start   Stale action is booting up!
// [Stale] › ☐  pending Retrieving Stale config from `.github/stale.yml`...
// ℹ  info      This will not be prefixed with Stale

```

Open to other thoughts on how this can be improved! Also the snapshot isn't capturing the prefix, so the tests are passing, but aren't 💯accurate. I guess we need a way to capture the output of the logger instead of just the text output.

---

- [X] Tests have been added/updated (if necessary)
- [X] Documentation has been updated (if necessary)