### PR TITLE
Mock process.on() in tests

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,6 +8,9 @@ describe('Toolkit', () => {
   let toolkit: Toolkit
 
   beforeEach(() => {
+    // Mock the `process` event emitter to prevent memory
+    // leaks on repeated calls in tests - used by Store.
+    process.on = jest.fn()
     toolkit = new Toolkit({ logger: new Signale({ disabled: true }) })
   })
 


### PR DESCRIPTION
**Why?**

@macklinu opened up #56 to track a memory leak warning in tests; this is due to too many calls to `process.on`. This PR mocks `process.on` in the larger test file, `index.test.ts`, where we instantiate a bunch of Toolkit instances; this way we aren't actually registering event handlers 😊 

Closes #56 

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)