### PR TITLE
Make `context.issue` and `context.repo` objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,23 +312,13 @@ The Git `sha` at which the action was triggered
 
 The name of the workflow that was triggered.
 
-#### tools.context.issue([object])
+#### tools.context.issue
 
-Return the `owner`, `repo`, and `number` params for making API requests against an issue or pull request. The object passed in will be merged with the repo params.
+The `owner`, `repo`, and `number` params for making API requests against an issue or pull request.
 
-```js
-const params = context.issue({body: 'Hello World!'})
-// Returns: {owner: 'username', repo: 'reponame', number: 123, body: 'Hello World!'}
-```
+#### tools.context.repo
 
-#### tools.context.repo([object])
-
-Return the `owner` and `repo` params for making API requests against a repository.
-
-```js
-const params = context.repo({path: '.github/config.yml'})
-// Returns: {owner: 'username', repo: 'reponame', path: '.github/config.yml'}
-```
+The `owner` and `repo` params for making API requests against a repository.
 
 ## Actions using actions-toolkit
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -70,47 +70,26 @@ export class Context {
     this.actor = process.env.GITHUB_ACTOR as string
   }
 
-  /**
-   * Return the `owner` and `repo` params for making API requests against a
-   * repository.
-   *
-   * ```js
-   * const params = context.repo({path: '.github/config.yml'})
-   * // Returns: {owner: 'username', repo: 'reponame', path: '.github/config.yml'}
-   * ```
-   *
-   * @param object - Params to be merged with the repo params.
-   *
-   */
-  public repo<T> (object?: T) {
+  public get issue () {
+    const payload = this.payload
+
+    return {
+      ...this.repo,
+      number: (payload.issue || payload.pull_request || payload).number
+    }
+  }
+
+  public get repo () {
     const repo = this.payload.repository
 
     if (!repo) {
-      throw new Error('context.repo() is not supported for this webhook event.')
+      throw new Error('context.repo is not supported for this webhook event.')
     }
 
-    return Object.assign({
+    return {
       owner: repo.owner.login,
       repo: repo.name
-    }, object)
+    }
   }
 
-  /**
-   * Return the `owner`, `repo`, and `number` params for making API requests
-   * against an issue or pull request. The object passed in will be merged with
-   * the repo params.
-   *
-   * ```js
-   * const params = context.issue({body: 'Hello World!'})
-   * // Returns: {owner: 'username', repo: 'reponame', number: 123, body: 'Hello World!'}
-   * ```
-   *
-   * @param object - Params to be merged with the issue params.
-   */
-  public issue<T> (object?: T) {
-    const payload = this.payload
-    return Object.assign({
-      number: (payload.issue || payload.pull_request || payload).number
-    }, this.repo(object))
-  }
 }

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -27,46 +27,23 @@ describe('Context', () => {
 
   describe('#repo', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.repo()).toEqual({ owner: 'JasonEtco', repo: 'test' })
+      expect(context.repo).toEqual({ owner: 'JasonEtco', repo: 'test' })
     })
 
-    it('merges attributes', () => {
-      expect(context.repo({ foo: 1, bar: 2 })).toEqual({
-        bar: 2, foo: 1, owner: 'JasonEtco', repo: 'test'
-      })
-    })
-
-    it('overrides repo attributes', () => {
-      expect(context.repo({ owner: 'muahaha' })).toEqual({
-        owner: 'muahaha', repo: 'test'
-      })
-    })
-
-    it('return error for context.repo() when repository doesn\'t exist', () => {
+    it('return error for context.repo when repository doesn\'t exist', () => {
       context.payload = {}
       try {
-        context.repo()
+        // tslint:disable-next-line no-unused-expression
+        context.repo
       } catch (e) {
-        expect(e.message).toMatch('context.repo() is not supported')
+        expect(e.message).toMatch('context.repo is not supported')
       }
     })
   })
 
   describe('#issue', () => {
     it('returns attributes from the repository payload', () => {
-      expect(context.issue()).toEqual({ owner: 'JasonEtco', repo: 'test', number: 1 })
-    })
-
-    it('merges attributes', () => {
-      expect(context.issue({ foo: 1, bar: 2 })).toEqual({
-        bar: 2, foo: 1, number: 1, owner: 'JasonEtco', repo: 'test'
-      })
-    })
-
-    it('overrides repo attributes', () => {
-      expect(context.issue({ owner: 'muahaha', number: 5 })).toEqual({
-        number: 5, owner: 'muahaha', repo: 'test'
-      })
+      expect(context.issue).toEqual({ owner: 'JasonEtco', repo: 'test', number: 1 })
     })
 
     it('works with pull_request payloads', () => {
@@ -74,14 +51,14 @@ describe('Context', () => {
         pull_request: { number: 2 },
         repository: { owner: { login: 'JasonEtco' }, name: 'test' }
       }
-      expect(context.issue()).toEqual({
+      expect(context.issue).toEqual({
         number: 2, owner: 'JasonEtco', repo: 'test'
       })
     })
 
     it('works with payload.number payloads', () => {
       context.payload = { number: 2, repository: { owner: { login: 'JasonEtco' }, name: 'test' } }
-      expect(context.issue()).toEqual({
+      expect(context.issue).toEqual({
         number: 2, owner: 'JasonEtco', repo: 'test'
       })
     })


### PR DESCRIPTION
The way that `context.issue` and `context.repo` are functions that merge their arguments has been a point of confusion for me quite a bit.

Given that Node supports object spread, and you can achieve the same goal with that, does it make sense for `context.issue` and `context.repo` to just be (frozen) objects, instead? Before I read over the readme in much more detail, it's how I expected it to work, and looks a little more idiomatic to me.

```javascript
const payload = context.issue({body: 'Hello, world!'})
```

vs

```javascript
const payload = {...context.issue, body: 'Hello, world!'}
```