### PR TITLE
Use logger in exit

### DIFF
--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,4 +1,4 @@
-// tslint:disable:no-console
+import { Signale } from 'signale'
 
 /**
  * The code to exit an action with a "success" state
@@ -14,11 +14,17 @@ export const FailureCode = 1
 export const NeutralCode = 78
 
 export class Exit {
+  public logger: Signale
+
+  constructor (logger: Signale) {
+    this.logger = logger
+  }
+
   /**
    * Stop the action with a "success" status
    */
   public success (message?: string) {
-    if (message) console.log(message)
+    if (message) this.logger.success(message)
     process.exit(SuccessCode)
   }
 
@@ -26,7 +32,7 @@ export class Exit {
    * Stop the action with a "neutral" status
    */
   public neutral (message?: string) {
-    if (message) console.log(message)
+    if (message) this.logger.info(message)
     process.exit(NeutralCode)
   }
 
@@ -34,7 +40,7 @@ export class Exit {
    * Stop the action with a "failed" status
    */
   public failure (message?: string) {
-    if (message) console.error(message)
+    if (message) this.logger.fatal(message)
     process.exit(FailureCode)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export class Toolkit {
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
 
-    this.exit = new Exit()
+    this.exit = new Exit(this.log)
     this.context = new Context()
     this.workspace = process.env.GITHUB_WORKSPACE as string
     this.token = process.env.GITHUB_TOKEN as string

--- a/tests/exit.test.ts
+++ b/tests/exit.test.ts
@@ -1,7 +1,15 @@
 import { Exit, FailureCode, NeutralCode, SuccessCode } from '../src/exit'
 
-type methods = 'success' | 'neutral' | 'failure'
-type logs = 'log' | 'error'
+enum methods {
+  Success = 'success',
+  Neutral = 'neutral',
+  Failure = 'failure'
+}
+
+enum logs {
+  Log = 'log',
+  Error = 'error'
+}
 
 describe('Exit', () => {
   let logger: any

--- a/tests/exit.test.ts
+++ b/tests/exit.test.ts
@@ -1,36 +1,39 @@
+import { Signale } from 'signale'
 import { Exit, FailureCode, NeutralCode, SuccessCode } from '../src/exit'
 
+// Need to type these to properly iterate
 enum methods {
   Success = 'success',
   Neutral = 'neutral',
   Failure = 'failure'
 }
 
-enum logs {
-  Log = 'log',
-  Error = 'error'
-}
+// Methods on the logging class
+type logs = keyof(Signale)
 
 describe('Exit', () => {
-  let logger: any
-
-  beforeEach(() => {
-    logger = { error: jest.fn(), log: jest.fn() }
-    console = logger
-
-    const p = global.process as any
-    p.exit = jest.fn()
-  })
-
-  const exit = new Exit()
-
   const tests = [
-    ['success', 'log', SuccessCode],
-    ['neutral', 'log', NeutralCode],
-    ['failure', 'error', FailureCode]
+    ['success', 'success', SuccessCode],
+    ['neutral', 'info', NeutralCode],
+    ['failure', 'fatal', FailureCode]
   ]
 
   describe.each(tests)('%s', (method, log, code) => {
+    let logger: Signale
+    let exit: Exit
+
+    beforeEach(() => {
+      // Create a logger to mock
+      logger = new Signale()
+      logger.success = jest.fn()
+      logger.info = jest.fn()
+      logger.fatal = jest.fn()
+
+      const p = global.process as any
+      p.exit = jest.fn()
+      exit = new Exit(logger)
+    })
+
     it('exits with the expected code', () => {
       exit[method as methods]()
       expect(process.exit).toHaveBeenCalledWith(code)
@@ -38,7 +41,7 @@ describe('Exit', () => {
 
     it('logs the expected message', () => {
       exit[method as methods]('hello')
-      expect(console[log as logs]).toHaveBeenCalledWith('hello')
+      expect(logger[log as logs]).toHaveBeenCalledWith('hello')
     })
   })
 })


### PR DESCRIPTION
**Why?**

Noticed this in #63 - the `Toolkit.exit` methods aren't using the fancy logger I worked so hard to implement in #45 😅

**How?**

This PR adds support for a `logger: Signale` to be passed to the `Exit` class constructor. In the `success`, `neutral` and `failure` methods, we now use the logger instead of `console.log`.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)