### PR TITLE
Add `secrets` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ const tools = new Toolkit({
 })
 ```
 
+#### secrets (optional)
+
+You can choose to pass a list of secrets that must be included in the workflow that runs your Action. This ensures that your Action has the secrets it needs to function correctly:
+
+```js
+const tools = new Toolkit({
+  secrets: ['SUPER_SECRET_KEY']
+})
+```
+
+If any of the listed secrets are missing, the Action will fail and log a message.
+
 ### Toolkit.run
 
 Run an asynchronous function that receives an instance of `Toolkit` as its argument. If the function throws an error (or returns a rejected promise), `Toolkit.run` will log the error and exit the action with a failure status code.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { Store } from './store'
 
 export interface ToolkitOptions {
   event?: string | string[],
+  secrets?: string[],
   logger?: Signale
 }
 
@@ -101,7 +102,10 @@ export class Toolkit {
     this.github = new GitHub(this.token)
     this.arguments = minimist(process.argv.slice(2))
     this.store = new Store(this.context.workflow, this.workspace)
+
+    // Check stuff
     this.checkAllowedEvents(this.opts.event)
+    this.checkRequiredSecrets(this.opts.secrets)
   }
 
   /**
@@ -280,5 +284,15 @@ export class Toolkit {
       const warning = `There are environment variables missing from this runtime, but would be present on GitHub.\n${list}`
       this.log.warn(warning)
     }
+  }
+
+  /**
+   * The Action should fail if there are secrets it needs but does not have
+   */
+  private checkRequiredSecrets (secrets?: string[]) {
+    if (!secrets) return
+    const requiredButMissing = secrets.filter(key => !process.env.hasOwnProperty(key))
+    const list = requiredButMissing.map(key => `- ${key}`).join('\n')
+    this.exit.failure(`The following secrets are required for this GitHub Action to run:\n${list}`)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,15 @@ import { GitHub } from './github'
 import { Store } from './store'
 
 export interface ToolkitOptions {
+  /**
+   * An optional event or list of events that are supported by this Action. If
+   * a different event triggers this Action, it will exit with a neutral status.
+   */
   event?: string | string[],
+  /**
+   * An optional list of secrets that are required for this Action to function. If
+   * any secrets are missing, this Action will exit with a failing status.
+   */
   secrets?: string[],
   logger?: Signale
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,8 +290,12 @@ export class Toolkit {
    * The Action should fail if there are secrets it needs but does not have
    */
   private checkRequiredSecrets (secrets?: string[]) {
-    if (!secrets) return
+    if (!secrets || secrets.length === 0) return
+    // Filter missing but required secrets
     const requiredButMissing = secrets.filter(key => !process.env.hasOwnProperty(key))
+    // Everything we need is here
+    if (requiredButMissing.length === 0) return
+    // Exit with a failing status
     const list = requiredButMissing.map(key => `- ${key}`).join('\n')
     this.exit.failure(`The following secrets are required for this GitHub Action to run:\n${list}`)
   }

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -31,7 +31,7 @@ Object {
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
 
-exports[`Toolkit#constructor exits if the event is not allowed with a single event 1`] = `
+exports[`Toolkit#constructor events exits if the event is not allowed with a single event 1`] = `
 Array [
   Array [
     "Event \`issues.opened\` is not supported by this action.",
@@ -39,7 +39,7 @@ Array [
 ]
 `;
 
-exports[`Toolkit#constructor exits if the event is not allowed with a single event with an action 1`] = `
+exports[`Toolkit#constructor events exits if the event is not allowed with a single event with an action 1`] = `
 Array [
   Array [
     "Event \`issues.opened\` is not supported by this action.",
@@ -47,7 +47,7 @@ Array [
 ]
 `;
 
-exports[`Toolkit#constructor exits if the event is not allowed with an array of events 1`] = `
+exports[`Toolkit#constructor events exits if the event is not allowed with an array of events 1`] = `
 Array [
   Array [
     "Event \`issues.opened\` is not supported by this action.",
@@ -55,7 +55,7 @@ Array [
 ]
 `;
 
-exports[`Toolkit#constructor exits if the event is not allowed with an array of events with actions 1`] = `
+exports[`Toolkit#constructor events exits if the event is not allowed with an array of events with actions 1`] = `
 Array [
   Array [
     "Event \`issues.opened\` is not supported by this action.",
@@ -63,7 +63,7 @@ Array [
 ]
 `;
 
-exports[`Toolkit#constructor logs the expected string with missing env vars 1`] = `
+exports[`Toolkit#constructor missing env vars logs the expected string with missing env vars 1`] = `
 Array [
   Array [
     "There are environment variables missing from this runtime, but would be present on GitHub.

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -71,3 +71,12 @@ Array [
   ],
 ]
 `;
+
+exports[`Toolkit#constructor secrets calls the exit.failure with missing secrets 1`] = `
+Array [
+  Array [
+    "The following secrets are required for this GitHub Action to run:
+- DO_NOT_EXIST",
+  ],
+]
+`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -255,6 +255,24 @@ describe('Toolkit#constructor', () => {
     expect(logger.warn.mock.calls).toMatchSnapshot()
   })
 
+  describe('secrets', () => {
+    it('does nothing when passed an empty array', () => {
+      logger.fatal = jest.fn()
+      new Toolkit({ logger, secrets: [] }) // tslint:disable-line:no-unused-expression
+      expect(logger.fatal).not.toHaveBeenCalled()
+    })
+
+    it('calls the exit.failure with missing secrets', () => {
+      // Delete this, juuuust in case
+      delete process.env.DO_NOT_EXIST
+
+      logger.fatal = jest.fn()
+      new Toolkit({ logger, secrets: ['DO_NOT_EXIST'] }) // tslint:disable-line:no-unused-expression
+      expect(logger.fatal).toHaveBeenCalled()
+      expect(logger.fatal.mock.calls).toMatchSnapshot()
+    })
+  })
+
   afterEach(() => {
     global.process.exit = exit
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -25,7 +25,7 @@ describe('Toolkit', () => {
       // Check that it returned a value as an async function
       expect(actual).toBe('hi')
     })
-    
+
     it('runs a non-async function passed to it', async () => {
       const spy = jest.fn(() => 'hi')
       const actual = await Toolkit.run(spy)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -262,6 +262,13 @@ describe('Toolkit#constructor', () => {
       expect(logger.fatal).not.toHaveBeenCalled()
     })
 
+    it('does nothing when no required secrets are missing', () => {
+      process.env.I_EXIST = 'boo'
+      logger.fatal = jest.fn()
+      new Toolkit({ logger, secrets: ['I_EXIST'] })
+      expect(logger.fatal).not.toHaveBeenCalled()
+    })
+
     it('calls the exit.failure with missing secrets', () => {
       // Delete this, juuuust in case
       delete process.env.DO_NOT_EXIST

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -214,36 +214,32 @@ describe('Toolkit#constructor', () => {
     p.exit = jest.fn()
   })
 
+  // tslint:disable:no-unused-expression
   it('exits if the event is not allowed with an array of events', () => {
-    // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: ['pull_request'] })
     expect(process.exit).toHaveBeenCalledWith(NeutralCode)
     expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('does not exit if the event is one of the allowed with an array of events', () => {
-    // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: ['pull_request', 'issues'] })
     expect(process.exit).not.toHaveBeenCalled()
     expect(logger.error).not.toHaveBeenCalled()
   })
 
   it('exits if the event is not allowed with a single event', () => {
-    // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: 'pull_request' })
     expect(process.exit).toHaveBeenCalledWith(NeutralCode)
     expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('exits if the event is not allowed with an array of events with actions', () => {
-    // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: ['pull_request.opened'] })
     expect(process.exit).toHaveBeenCalledWith(NeutralCode)
     expect(logger.error.mock.calls).toMatchSnapshot()
   })
 
   it('exits if the event is not allowed with a single event with an action', () => {
-    // tslint:disable-next-line:no-unused-expression
     new Toolkit({ logger, event: 'pull_request.opened' })
     expect(process.exit).toHaveBeenCalledWith(NeutralCode)
     expect(logger.error.mock.calls).toMatchSnapshot()
@@ -251,14 +247,14 @@ describe('Toolkit#constructor', () => {
 
   it('logs the expected string with missing env vars', () => {
     delete process.env.HOME
-    new Toolkit({ logger }) // tslint:disable-line:no-unused-expression
+    new Toolkit({ logger })
     expect(logger.warn.mock.calls).toMatchSnapshot()
   })
 
   describe('secrets', () => {
     it('does nothing when passed an empty array', () => {
       logger.fatal = jest.fn()
-      new Toolkit({ logger, secrets: [] }) // tslint:disable-line:no-unused-expression
+      new Toolkit({ logger, secrets: [] })
       expect(logger.fatal).not.toHaveBeenCalled()
     })
 
@@ -267,12 +263,13 @@ describe('Toolkit#constructor', () => {
       delete process.env.DO_NOT_EXIST
 
       logger.fatal = jest.fn()
-      new Toolkit({ logger, secrets: ['DO_NOT_EXIST'] }) // tslint:disable-line:no-unused-expression
+      new Toolkit({ logger, secrets: ['DO_NOT_EXIST'] })
       expect(logger.fatal).toHaveBeenCalled()
       expect(logger.fatal.mock.calls).toMatchSnapshot()
     })
   })
 
+  // tslint:enable:no-unused-expression
   afterEach(() => {
     global.process.exit = exit
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -215,40 +215,44 @@ describe('Toolkit#constructor', () => {
   })
 
   // tslint:disable:no-unused-expression
-  it('exits if the event is not allowed with an array of events', () => {
-    new Toolkit({ logger, event: ['pull_request'] })
-    expect(process.exit).toHaveBeenCalledWith(NeutralCode)
-    expect(logger.error.mock.calls).toMatchSnapshot()
+  describe('missing env vars', () => {
+    it('logs the expected string with missing env vars', () => {
+      delete process.env.HOME
+      new Toolkit({ logger })
+      expect(logger.warn.mock.calls).toMatchSnapshot()
+    })
   })
 
-  it('does not exit if the event is one of the allowed with an array of events', () => {
-    new Toolkit({ logger, event: ['pull_request', 'issues'] })
-    expect(process.exit).not.toHaveBeenCalled()
-    expect(logger.error).not.toHaveBeenCalled()
-  })
+  describe('events', () => {
+    it('exits if the event is not allowed with an array of events', () => {
+      new Toolkit({ logger, event: ['pull_request'] })
+      expect(process.exit).toHaveBeenCalledWith(NeutralCode)
+      expect(logger.error.mock.calls).toMatchSnapshot()
+    })
 
-  it('exits if the event is not allowed with a single event', () => {
-    new Toolkit({ logger, event: 'pull_request' })
-    expect(process.exit).toHaveBeenCalledWith(NeutralCode)
-    expect(logger.error.mock.calls).toMatchSnapshot()
-  })
+    it('does not exit if the event is one of the allowed with an array of events', () => {
+      new Toolkit({ logger, event: ['pull_request', 'issues'] })
+      expect(process.exit).not.toHaveBeenCalled()
+      expect(logger.error).not.toHaveBeenCalled()
+    })
 
-  it('exits if the event is not allowed with an array of events with actions', () => {
-    new Toolkit({ logger, event: ['pull_request.opened'] })
-    expect(process.exit).toHaveBeenCalledWith(NeutralCode)
-    expect(logger.error.mock.calls).toMatchSnapshot()
-  })
+    it('exits if the event is not allowed with a single event', () => {
+      new Toolkit({ logger, event: 'pull_request' })
+      expect(process.exit).toHaveBeenCalledWith(NeutralCode)
+      expect(logger.error.mock.calls).toMatchSnapshot()
+    })
 
-  it('exits if the event is not allowed with a single event with an action', () => {
-    new Toolkit({ logger, event: 'pull_request.opened' })
-    expect(process.exit).toHaveBeenCalledWith(NeutralCode)
-    expect(logger.error.mock.calls).toMatchSnapshot()
-  })
+    it('exits if the event is not allowed with an array of events with actions', () => {
+      new Toolkit({ logger, event: ['pull_request.opened'] })
+      expect(process.exit).toHaveBeenCalledWith(NeutralCode)
+      expect(logger.error.mock.calls).toMatchSnapshot()
+    })
 
-  it('logs the expected string with missing env vars', () => {
-    delete process.env.HOME
-    new Toolkit({ logger })
-    expect(logger.warn.mock.calls).toMatchSnapshot()
+    it('exits if the event is not allowed with a single event with an action', () => {
+      new Toolkit({ logger, event: 'pull_request.opened' })
+      expect(process.exit).toHaveBeenCalledWith(NeutralCode)
+      expect(logger.error.mock.calls).toMatchSnapshot()
+    })
   })
 
   describe('secrets', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,6 +14,31 @@ describe('Toolkit', () => {
     toolkit = new Toolkit({ logger: new Signale({ disabled: true }) })
   })
 
+  describe('.run', () => {
+    it('runs the async function passed to it', async () => {
+      const spy = jest.fn(() => Promise.resolve('hi'))
+      const actual = await Toolkit.run(spy)
+      // Test that the function was called
+      expect(spy).toHaveBeenCalled()
+      // Make sure it was called with a Toolkit instance
+      expect((spy.mock.calls as any)[0][0]).toBeInstanceOf(Toolkit)
+      // Check that it returned a value as an async function
+      expect(actual).toBe('hi')
+    })
+
+    it('logs and fails when the function throws an error', async () => {
+      const err = new Error('Whoops!')
+      const exitFailure = jest.fn()
+
+      await Toolkit.run(async twolkit => {
+        twolkit.exit.failure = exitFailure
+        throw err
+      })
+
+      expect(exitFailure).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('#github', () => {
     it('returns a GitHub client', () => {
       expect(toolkit.github).toBeInstanceOf(Object)
@@ -156,31 +181,6 @@ describe('Toolkit', () => {
     it('runs the command in the workspace with some options', async () => {
       const result = await toolkit.runInWorkspace('throw', undefined, { reject: false })
       expect(result).toMatchSnapshot()
-    })
-  })
-
-  describe('.run', () => {
-    it('runs the async function passed to it', async () => {
-      const spy = jest.fn(() => Promise.resolve('hi'))
-      const actual = await Toolkit.run(spy)
-      // Test that the function was called
-      expect(spy).toHaveBeenCalled()
-      // Make sure it was called with a Toolkit instance
-      expect((spy.mock.calls as any)[0][0]).toBeInstanceOf(Toolkit)
-      // Check that it returned a value as an async function
-      expect(actual).toBe('hi')
-    })
-
-    it('logs and fails when the function throws an error', async () => {
-      const err = new Error('Whoops!')
-      const exitFailure = jest.fn()
-
-      await Toolkit.run(async twolkit => {
-        twolkit.exit.failure = exitFailure
-        throw err
-      })
-
-      expect(exitFailure).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
**Why?**

Its impossible to enforce that your action is running in the appropriate environment. For that reason, I introduced the `events` option in #36 - in a similar vein, this PR introduces the `secrets` option to help Action authors ensure that users of the Action include the relevant secrets, without having to handle that logic.

Closes #65 

**How?**

I've add a new private method `checkRequiredSecrets` that, as you may imagine, checks the secrets passed in the constructor. It's pretty simple:

https://github.com/JasonEtco/actions-toolkit/blob/f4df76b5a076b2521a47bb62f5f40d12f2571a06/src/index.ts#L300-L309

If any of the required secrets are missing, the action will fail and an error message will be logged.

I also unintentionally bloated this PR by moving some tests around and adding comments to stuff - it made sense to do so given the addition of a new constructor option.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)