### PR TITLE
Support non-async functions in Toolkit.run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,12 +31,14 @@ export class Toolkit {
    * }, { event: 'push' })
    * ```
    */
-  public static async run (func: (tools: Toolkit) => Promise<unknown>, opts?: ToolkitOptions) {
+  public static async run (func: (tools: Toolkit) => unknown, opts?: ToolkitOptions) {
     const tools = new Toolkit(opts)
 
-    return func(tools).catch(err => {
+    try {
+      return await func(tools)
+    } catch (err) {
       tools.exit.failure(err)
-    })
+    }
   }
 
   public context: Context

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,10 @@ export class Toolkit {
     const tools = new Toolkit(opts)
 
     try {
-      return await func(tools)
+      const ret = func(tools)
+      // If the return value of the provided function is an unresolved Promise
+      // await that Promise before return the value, otherwise return as normal
+      return ret instanceof Promise ? await ret : ret
     } catch (err) {
       tools.exit.failure(err)
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -171,6 +171,13 @@ describe('Toolkit', () => {
       expect(actual).toBe('hi')
     })
 
+    it('runs a non-async function passed to it', async () => {
+      const spy = jest.fn(() => 'hi')
+      const actual = await Toolkit.run(spy)
+      // Check that it returned a value as an async function
+      expect(actual).toBe('hi')
+    })
+
     it('logs and fails when the function throws an error', async () => {
       const err = new Error('Whoops!')
       const exitFailure = jest.fn()


### PR DESCRIPTION
**Why?**

I accidentally discovered that `Toolkit.run` (#63) doesn't support non-async functions because of its use of `.catch()`. I don't know if this was intentional, but it's easy enough to support synchronous functions that we might as well do it. There are use-cases like checking things against the payload or in the repo that can be synchronous, so we should support those.

This is the error (I added a test to produce it):

```
  ● Toolkit › .run › runs a non-async function passed to it

    TypeError: func(...).catch is not a function

      35 |     const tools = new Toolkit(opts)
      36 | 
    > 37 |     return func(tools).catch(err => {
         |                             ^
      38 |       tools.exit.failure(err)
      39 |     })
      40 |   }

      at Function.<anonymous> (src/index.ts:37:29)
```

Makes sense, because functions that don't return a Promise don't have a `catch` method on their return value.

**How?**

Just changed the `.catch()` for a `try/catch` block, and changed the function's type's return value from `Promise<unknown>` to just `unknown`.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)