### PR TITLE
Fix missing methods on `tools.log`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -573,9 +573,9 @@
       "dev": true
     },
     "@types/signale": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/signale/-/signale-1.2.0.tgz",
-      "integrity": "sha512-67bRC/sXh/d6hS+apQ23v3btDC72P8lsIlNZULprtKpCRxrmA9Jd3spHR54HP0U2D63HjCWlhp17L/nuyh2AXw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/signale/-/signale-1.2.1.tgz",
+      "integrity": "sha512-mV6s2VgcBC16Jb+1EwulgRrrZBT93V4JCILkNPg31rvvSK6LRQQGU8R/SUivgHjDZ5LJZu/yL2kMF8j85YQTnA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4243,7 +4243,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -4746,7 +4746,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4982,7 +4982,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -5077,9 +5077,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "signale": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/signale/-/signale-1.3.0.tgz",
-      "integrity": "sha512-TyFhsQ9wZDYDfsPqWMyjCxsDoMwfpsT0130Mce7wDiVCSDdtWSg83dOqoj8aGpGCs3n1YPcam6sT1OFPuGT/OQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "requires": {
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
@@ -6093,7 +6093,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -6123,7 +6123,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/minimist": "^1.2.0",
     "@types/nock": "^9.3.1",
     "@types/node": "^11.9.4",
-    "@types/signale": "^1.2.0",
+    "@types/signale": "^1.2.1",
     "jest": "^24.5.0",
     "nock": "^10.0.6",
     "rimraf": "^2.6.3",
@@ -62,7 +62,7 @@
     "flat-cache": "^2.0.1",
     "js-yaml": "^3.12.1",
     "minimist": "^1.2.0",
-    "signale": "^1.3.0"
+    "signale": "^1.4.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/@types/signale/index.d.ts
+++ b/src/@types/signale/index.d.ts
@@ -2,6 +2,10 @@ import 'signale'
 
 declare module 'signale' {
   interface SignaleBase<TTypes extends string = DefaultMethods> {
-    public disable (): void
+    disable (): void
+    enable (): void
+    isEnabled (): boolean
+    addSecrets (secrets: any[]): void
+    clearSecrets (): void
   }
 }

--- a/src/@types/signale/index.d.ts
+++ b/src/@types/signale/index.d.ts
@@ -2,10 +2,29 @@ import 'signale'
 
 declare module 'signale' {
   interface SignaleBase<TTypes extends string = DefaultMethods> {
-    disable (): void
-    enable (): void
-    isEnabled (): boolean
-    addSecrets (secrets: any[]): void
-    clearSecrets (): void
+    /**
+     * Disables the logging functionality of all loggers belonging to a specific instance.
+     */
+    disable(): void;
+    /**
+     * Enables the logging functionality of all loggers belonging to a specific instance.
+     */
+    enable(): void;
+    /**
+     * Checks whether the logging functionality of a specific instance is enabled.
+     *
+     * @returns a boolean that describes whether or not the logger is enabled.
+     */
+    isEnabled(): boolean;
+    /**
+     * Adds new secrets/sensitive-information to the targeted Signale instance.
+     *
+     * @param secrets Array holding the secrets/sensitive-information to be filtered out.
+     */
+    addSecrets(secrets: string[] | number[]): void;
+    /**
+     * Removes all secrets/sensitive-information from the targeted Signale instance.
+     */
+    clearSecrets(): void;
   }
 }

--- a/src/@types/signale/index.d.ts
+++ b/src/@types/signale/index.d.ts
@@ -1,0 +1,7 @@
+import 'signale'
+
+declare module 'signale' {
+  interface SignaleBase<TTypes extends string = DefaultMethods> {
+    public disable (): void
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,9 @@ export class Toolkit {
   private wrapLogger (logger?: Signale) {
     if (!logger) logger = new Signale({ config: { underlineLabel: false } })
     const fn = logger.info.bind(logger)
-    return Object.assign(fn, logger)
+    const wrapped = Object.assign(fn, logger)
+    Object.setPrototypeOf(wrapped, Signale.prototype)
+    return wrapped
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,9 +268,12 @@ export class Toolkit {
    */
   private wrapLogger (logger?: Signale) {
     if (!logger) logger = new Signale({ config: { underlineLabel: false } })
+    // Create a callable function
     const fn = logger.info.bind(logger)
+    // Add the log methods onto the function
     const wrapped = Object.assign(fn, logger)
-    Object.setPrototypeOf(wrapped, Signale.prototype)
+    // Clone the prototype
+    Object.setPrototypeOf(wrapped, logger)
     return wrapped
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -203,6 +203,10 @@ describe('Toolkit', () => {
       expect(logger.info).toHaveBeenCalledTimes(2)
       expect(logger.info).toHaveBeenCalledWith('Hello!')
       expect(logger.info).toHaveBeenCalledWith('Hi!')
+
+      // Ensure that prototype methods were carried over
+      expect(twolkit.log.disable).toBeInstanceOf(Function)
+      expect(twolkit.log.disable).toEqual(logger.disable)
     })
   })
 })


### PR DESCRIPTION
**Why?**

I've been wondering why `tools.log.disable()` doesn't work; it's a handy method that would disable the logger in tests. Turns out `Object.assign()` doesn't clone `prototype` methods, so the `wrapLogger` private method that enabled a callable `tools.log` was omitting unbound methods:

```js
// This works
tools.log.info()
// This does not
tools.log.disable()
```

**How?**

`Object.setPrototypeOf` is magical. Unfortunately this required some type declaration merging, because `@types/signale` does not have the `disable()` method.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)