### PR TITLE
Revert "Throw on missing env vars"

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ const tools = new Toolkit({
 })
 ```
 
-#### Required environment variables
-
-Instantiating the class without [all of the environment variables that are present in the GitHub Actions runtime](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables) will throw an error with a list of the missing variables. This is to ensure reliability and predictability. When working locally, you may choose to use [`dotenv`](https://www.npmjs.com/package/dotenv) to simulate the Actions environment.
-
 ### tools.github
 
 Returns an [Octokit SDK](https://octokit.github.io/rest.js) client authenticated for this repository. See [https://octokit.github.io/rest.js](https://octokit.github.io/rest.js) for the API.

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,8 @@ export class Toolkit {
       'GITHUB_EVENT_PATH',
       'GITHUB_WORKSPACE',
       'GITHUB_SHA',
-      'GITHUB_REF'
+      'GITHUB_REF',
+      'GITHUB_TOKEN'
     ]
 
     const requiredButMissing = requiredEnvVars.filter(key => !process.env.hasOwnProperty(key))
@@ -254,7 +255,7 @@ export class Toolkit {
       // This isn't being run inside of a GitHub Action environment!
       const list = requiredButMissing.map(key => `- ${key}`).join('\n')
       const warning = `There are environment variables missing from this runtime, but would be present on GitHub.\n${list}`
-      throw new Error(warning)
+      this.log.warn(warning)
     }
   }
 }

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -31,11 +31,6 @@ Object {
 
 exports[`Toolkit #runInWorkspace runs the command in the workspace with some options 1`] = `[Error: spawn throw ENOENT]`;
 
-exports[`Toolkit #warnForMissingEnvVars throws with the expected string 1`] = `
-"There are environment variables missing from this runtime, but would be present on GitHub.
-- HOME"
-`;
-
 exports[`Toolkit#constructor exits if the event is not allowed with a single event 1`] = `
 Array [
   Array [
@@ -64,6 +59,15 @@ exports[`Toolkit#constructor exits if the event is not allowed with an array of 
 Array [
   Array [
     "Event \`issues.opened\` is not supported by this action.",
+  ],
+]
+`;
+
+exports[`Toolkit#constructor logs the expected string with missing env vars 1`] = `
+Array [
+  Array [
+    "There are environment variables missing from this runtime, but would be present on GitHub.
+- HOME",
   ],
 ]
 `;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -159,12 +159,18 @@ describe('Toolkit', () => {
     })
   })
 
-  describe('#warnForMissingEnvVars', () => {
-    it('throws with the expected string', () => {
-      const home = process.env.HOME
-      delete process.env.HOME
-      expect(() => new Toolkit()).toThrowErrorMatchingSnapshot()
-      process.env.HOME = home
+  describe('#wrapLogger', () => {
+    it('wraps the provided logger and allows for a callable class', () => {
+      const logger = new Signale() as jest.Mocked<Signale>
+      logger.info = jest.fn()
+      const twolkit = new Toolkit({ logger })
+
+      twolkit.log('Hello!')
+      twolkit.log.info('Hi!')
+
+      expect(logger.info).toHaveBeenCalledTimes(2)
+      expect(logger.info).toHaveBeenCalledWith('Hello!')
+      expect(logger.info).toHaveBeenCalledWith('Hi!')
     })
   })
 })
@@ -216,6 +222,12 @@ describe('Toolkit#constructor', () => {
     new Toolkit({ logger, event: 'pull_request.opened' })
     expect(process.exit).toHaveBeenCalledWith(NeutralCode)
     expect(logger.error.mock.calls).toMatchSnapshot()
+  })
+
+  it('logs the expected string with missing env vars', () => {
+    delete process.env.HOME
+    new Toolkit({ logger }) // tslint:disable-line:no-unused-expression
+    expect(logger.warn.mock.calls).toMatchSnapshot()
   })
 
   afterEach(() => {


### PR DESCRIPTION
It turns out that this causes unnecessary friction, and locks us into a scenario where we depend on every environment variable to exist. In some cases `GITHUB_REF` isn't present. We can omit that one from the list, but I think that this toes the line of being _too_ strict.