### PR TITLE
Remove GITHUB_REF and GITHUB_TOKEN from required env vars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -285,9 +285,7 @@ export class Toolkit {
       'GITHUB_EVENT_NAME',
       'GITHUB_EVENT_PATH',
       'GITHUB_WORKSPACE',
-      'GITHUB_SHA',
-      'GITHUB_REF',
-      'GITHUB_TOKEN'
+      'GITHUB_SHA'
     ]
 
     const requiredButMissing = requiredEnvVars.filter(key => !process.env.hasOwnProperty(key))


### PR DESCRIPTION
**Why?**

@gr2m pointed out in #70 that we still don't want to warn on a missing `GITHUB_REF` or `GITHUB_TOKEN` environment variables - the former because its not present for every event, and the latter because its an optional secret.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)