### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/actions/publish-release/publish_release
+++ b/.github/actions/publish-release/publish_release
@@ -25,7 +25,7 @@ printf "//%s/:_authToken=%s\\nregistry=%s\\nstrict-ssl=%s" "$NPM_REGISTRY_URL" "
 
 chmod 0600 "$NPM_CONFIG_USERCONFIG"
 
-FILE=/release-workflow-tag
+FILE=./release-workflow-tag
 if [ ! -f $FILE ]; then
   echo "Publishing to @latest"
   npm publish

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,19 +1,33 @@
 workflow "Publish a release to npm" {
   on = "release"
-  resolves = ["Validate release", "Publish release"]
+  resolves = [
+    "Validate release",
+    "Publish release",
+  ]
 }
 
-action "GitHub Action for npm" {
-  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+action "npm ci" {
+  uses = "docker://node:alpine"
   args = "ci"
+  runs = "npm"
 }
 
 action "Validate release" {
   uses = "JasonEtco/validate-semver-release@master"
 }
 
+action "npm run build" {
+  uses = "docker://node:alpine"
+  needs = [
+    "npm ci",
+    "Validate release",
+  ]
+  runs = "npm"
+  args = "run build"
+}
+
 action "Publish release" {
   uses = "./.github/actions/publish-release"
-  needs = ["GitHub Action for npm", "Validate release"]
+  needs = ["npm run build"]
   secrets = ["NPM_AUTH_TOKEN"]
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "build": "rimraf lib && tsc -p tsconfig.json",
     "lint": "tslint --project tests",
     "test": "tsc --noEmit -p tests && jest --coverage && npm run lint",
-    "test:update": "tsc --noEmit -p tests && jest --coverage -u && npm run lint",
-    "prepare": "npm test && npm run build"
+    "test:update": "tsc --noEmit -p tests && jest --coverage -u && npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Why?**

The publishing workflow has been broken this whole time because of either a broken workflow or an incorrect file path. I've been using this for beta releases on #62 and its 👌 

**How?**

I've cherry-picked these commits from #62 - figured they deserved their own PR, and it'll help cleanup #62.

Some key changes:

* Removed the `prepare` script, it was causing problems by publishing empty lib folders
* Added a separate `npm run build` Action
* Fixed the path to the `release-workflow-tag` file, which may include `beta` or `next`.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)