### PR TITLE
Use GITHUB_REPOSITORY for context.repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ The `owner`, `repo`, and `number` params for making API requests against an issu
 
 #### tools.context.repo
 
-The `owner` and `repo` params for making API requests against a repository.
+The `owner` and `repo` params for making API requests against a repository. This uses the `GITHUB_REPOSITORY` environment variable under the hood.
 
 ## Actions using actions-toolkit
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -81,7 +81,7 @@ export class Context {
 
   public get repo () {
     if (!process.env.GITHUB_REPOSITORY) {
-      throw new Error('To use context.repo, you must have a GITHUB_REPOSITORY environment variable.')
+      throw new Error('context.repo requires a GITHUB_REPOSITORY environment variable like \'owner/repo\'')
     }
 
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')

--- a/src/context.ts
+++ b/src/context.ts
@@ -80,16 +80,11 @@ export class Context {
   }
 
   public get repo () {
-    const repo = this.payload.repository
-
-    if (!repo) {
-      throw new Error('context.repo is not supported for this webhook event.')
+    if (!process.env.GITHUB_REPOSITORY) {
+      throw new Error('To use context.repo, you must have a GITHUB_REPOSITORY environment variable.')
     }
 
-    return {
-      owner: repo.owner.login,
-      repo: repo.name
-    }
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
+    return { owner, repo }
   }
-
 }

--- a/tests/__snapshots__/context.test.ts.snap
+++ b/tests/__snapshots__/context.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Context #repo return error for context.repo when repository doesn't exist 1`] = `"To use context.repo, you must have a GITHUB_REPOSITORY environment variable."`;
+exports[`Context #repo return error for context.repo when repository doesn't exist 1`] = `"context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'"`;
 
 exports[`Context .payload returns the payload object 1`] = `
 Object {

--- a/tests/__snapshots__/context.test.ts.snap
+++ b/tests/__snapshots__/context.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Context #repo return error for context.repo when repository doesn't exist 1`] = `"To use context.repo, you must have a GITHUB_REPOSITORY environment variable."`;
+
 exports[`Context .payload returns the payload object 1`] = `
 Object {
   "action": "opened",

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -31,13 +31,10 @@ describe('Context', () => {
     })
 
     it('return error for context.repo when repository doesn\'t exist', () => {
-      context.payload = {}
-      try {
-        // tslint:disable-next-line no-unused-expression
-        context.repo
-      } catch (e) {
-        expect(e.message).toMatch('context.repo is not supported')
-      }
+      const before = process.env.GITHUB_REPOSITORY
+      delete process.env.GITHUB_REPOSITORY
+      expect(() => context.repo).toThrowErrorMatchingSnapshot()
+      process.env.GITHUB_REPOSITORY = before
     })
   })
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,7 +6,7 @@ Object.assign(process.env, {
   GITHUB_EVENT_NAME: 'issues',
   GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'issues.opened.json'),
   GITHUB_REF: 'master',
-  GITHUB_REPOSITORY: 'JasonEtco/actydoo',
+  GITHUB_REPOSITORY: 'JasonEtco/test',
   GITHUB_SHA: '123abc',
   GITHUB_TOKEN: '456def',
   GITHUB_WORKFLOW: 'my-workflow',


### PR DESCRIPTION
**Why?**

I've learned that not all events come with a `repository` object on the `event.json` - so using `context.repo` becomes broken. Now, this is already handled by the error in the getter, _but_ since all we're doing is getting a `{ owner, repo }` object, we can do so from the `GITHUB_REPOSITORY` environment variable instead!

**How?**

I've swapped out getting the owner and name from the payload to splitting `GITHUB_REPOSITORY` on `'/'`.

This is going to be a breaking change for a lot of tests, so I'm grouping it in with v2.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)