### PR TITLE
Move signale, minimist, execa types to deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,9 +517,8 @@
     },
     "@types/execa": {
       "version": "0.9.0",
-      "resolved": "http://registry.npmjs.org/@types/execa/-/execa-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/execa/-/execa-0.9.0.tgz",
       "integrity": "sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -553,9 +552,8 @@
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/nock": {
       "version": "9.3.1",
@@ -569,14 +567,12 @@
     "@types/node": {
       "version": "11.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
-      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==",
-      "dev": true
+      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA=="
     },
     "@types/signale": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/signale/-/signale-1.2.1.tgz",
       "integrity": "sha512-mV6s2VgcBC16Jb+1EwulgRrrZBT93V4JCILkNPg31rvvSK6LRQQGU8R/SUivgHjDZ5LJZu/yL2kMF8j85YQTnA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -31,13 +31,10 @@
   "homepage": "https://github.com/JasonEtco/actions-toolkit#readme",
   "devDependencies": {
     "@types/dotenv": "^6.1.0",
-    "@types/execa": "^0.9.0",
     "@types/jest": "^24.0.11",
     "@types/js-yaml": "^3.12.0",
-    "@types/minimist": "^1.2.0",
     "@types/nock": "^9.3.1",
     "@types/node": "^11.9.4",
-    "@types/signale": "^1.2.1",
     "jest": "^24.5.0",
     "nock": "^10.0.6",
     "rimraf": "^2.6.3",
@@ -56,6 +53,9 @@
   "dependencies": {
     "@octokit/graphql": "^2.0.1",
     "@octokit/rest": "^16.15.0",
+    "@types/execa": "^0.9.0",
+    "@types/minimist": "^1.2.0",
+    "@types/signale": "^1.2.1",
     "enquirer": "^2.3.0",
     "execa": "^1.0.0",
     "flat-cache": "^2.0.1",


### PR DESCRIPTION
**Why?**

This PR moves variables type definition packages from `devDependencies` to `dependencies`, so that TypeScript projects can use those types.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)