### PR TITLE
Use generics for some Toolkit methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export class Toolkit {
    * const cfg = toolkit.config('myaction')
    * ```
    */
-  public config <T = object> (key: string): T {
+  public config <T = any> (key: string): T {
     if (/\..+rc/.test(key)) {
       // It's a file like .npmrc or .eslintrc!
       return JSON.parse(this.getFile(key))
@@ -180,7 +180,7 @@ export class Toolkit {
       return yaml.safeLoad(this.getFile(key))
     } else {
       // It's a regular object key in the package.json
-      const pkg = this.getPackageJSON() as any
+      const pkg = this.getPackageJSON<T>() as any
       return pkg[key]
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class Toolkit {
   constructor (opts: ToolkitOptions = {}) {
     this.opts = opts
 
-    // Disable the underline to prevent extra white space in the Actions log output
+    // Create the logging instance
     this.log = this.wrapLogger(
       opts.logger || new Signale({ config: { underlineLabel: false } })
     )
@@ -111,12 +111,15 @@ export class Toolkit {
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
 
-    this.exit = new Exit(this.log)
-    this.context = new Context()
+    // Memoize environment variables and arguments
     this.workspace = process.env.GITHUB_WORKSPACE as string
     this.token = process.env.GITHUB_TOKEN as string
-    this.github = new GitHub(this.token)
     this.arguments = minimist(process.argv.slice(2))
+
+    // Setup nested objects
+    this.exit = new Exit(this.log)
+    this.context = new Context()
+    this.github = new GitHub(this.token)
     this.store = new Store(this.context.workflow, this.workspace)
 
     // Check stuff

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export class Toolkit {
    * const pkg = toolkit.getPackageJSON()
    * ```
    */
-  public getPackageJSON (): object {
+  public getPackageJSON <T = object> (): T {
     const pathToPackage = path.join(this.workspace, 'package.json')
     if (!fs.existsSync(pathToPackage)) throw new Error('package.json could not be found in your project\'s root.')
     return require(pathToPackage)
@@ -171,7 +171,7 @@ export class Toolkit {
    * const cfg = toolkit.config('myaction')
    * ```
    */
-  public config (key: string): object {
+  public config <T = object> (key: string): T {
     if (/\..+rc/.test(key)) {
       // It's a file like .npmrc or .eslintrc!
       return JSON.parse(this.getFile(key))

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,9 @@ export class Toolkit {
     this.opts = opts
 
     // Disable the underline to prevent extra white space in the Actions log output
-    this.log = this.wrapLogger(opts.logger)
+    this.log = this.wrapLogger(
+      opts.logger || new Signale({ config: { underlineLabel: false } })
+    )
 
     // Print a console warning for missing environment variables
     this.warnForMissingEnvVars()
@@ -267,8 +269,7 @@ export class Toolkit {
   /**
    * Wrap a Signale logger so that its a callable class
    */
-  private wrapLogger (logger?: Signale) {
-    if (!logger) logger = new Signale({ config: { underlineLabel: false } })
+  private wrapLogger (logger: Signale) {
     // Create a callable function
     const fn = logger.info.bind(logger)
     // Add the log methods onto the function

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ export class Toolkit {
       return yaml.safeLoad(this.getFile(key))
     } else {
       // It's a regular object key in the package.json
-      const pkg = this.getPackageJSON<T>() as any
+      const pkg = this.getPackageJSON<any>()
       return pkg[key]
     }
   }


### PR DESCRIPTION
**Why?**

Another round of improving types for various things, for better use in Actions written in ~T~HypeScript.

**How?**

Converted `getPackageJSON` and `config` to use generics, to allow passing a type to return that type as an actual object.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)