### PR TITLE
Update README.md `created` -> `opened`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ And/or strings that include an action (what actually happened to trigger this ev
 
 ```js
 const tools = new Toolkit({
-  event: ['issues.created']
+  event: ['issues.opened']
 })
 ```
 


### PR DESCRIPTION
Reading the documentation on actions, it seems that `created` is not a valid workflow configuration. `opened` is.

https://developer.github.com/actions/managing-workflows/workflow-configuration-options/#events-supported-in-workflow-files

**Why?**

<!-- What is the motivation behind this change? Link to issues if possible. -->

**How?**

<!-- Talk about your implementation -->

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)