### PR TITLE
Changed feather icon link based on discussion in #68

### DIFF
--- a/bin/create-action.js
+++ b/bin/create-action.js
@@ -63,7 +63,7 @@ async function getActionMetadata () {
     {
       type: 'autocomplete',
       name: 'icon',
-      message: 'Choose an icon for your action. Visit https://feathericons.com for a visual reference.',
+      message: 'Choose an icon for your action. Visit https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#supported-feather-icons for a visual reference.',
       choices: icons,
       limit: 10
     },

--- a/bin/template/Dockerfile
+++ b/bin/template/Dockerfile
@@ -13,7 +13,7 @@ FROM node:slim
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"=":NAME"
 LABEL "com.github.actions.description"=":DESCRIPTION"
-# Here are all of the available icons: https://feathericons.com/
+# Here are all of the available icons: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#supported-feather-icons
 LABEL "com.github.actions.icon"=":ICON"
 # And all of the available colors: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#label
 LABEL "com.github.actions.color"=":COLOR"

--- a/tests/__snapshots__/create-action.test.js.snap
+++ b/tests/__snapshots__/create-action.test.js.snap
@@ -16,7 +16,7 @@ FROM node:slim
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"="My Project Name"
 LABEL "com.github.actions.description"="A cool project"
-# Here are all of the available icons: https://feathericons.com/
+# Here are all of the available icons: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#supported-feather-icons
 LABEL "com.github.actions.icon"="anchor"
 # And all of the available colors: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#label
 LABEL "com.github.actions.color"="blue"


### PR DESCRIPTION
**Why?**

In issue #68 the link to supported icons is not reflected in the template.

**How?**

Updated the link in the comment.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)