### PR TITLE
Add Node.js 12 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: node_js
 node_js:
   - "10"
   - "11"
+  - "12"
 
 notifications:
   disabled: true


### PR DESCRIPTION
**Why?**

Node.js 12 has been released on `2019-04-23`, so I've added this version to the Travis CI build matrix to run the tests on this version to make sure that everything is working.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)