### PR TITLE
add link to octokit/graphql repo for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ You can also make GraphQL requests:
 ```js
 const result = await tools.github.graphql(query, variables)
 ```
+See [https://github.com/octokit/graphql.js](https://github.com/octokit/graphql.js) for more details on how to leverage the GraphQL API.
 
 <br>
 


### PR DESCRIPTION
**Why?**
close #94 

Upon further review, there is not a need to specifically mention how headers can be used. Link directly to the documentation is more than helpful.

<!-- What is the motivation behind this change? Link to issues if possible. -->

**How?**
I added a link to the @octokit/graphql repo. I found this documentation not very discoverable and something I will follow up with that project on. But for now, I think adding this link would help in discovering more details on implementing graphql with this library.
<!-- Talk about your implementation -->

---

- [ ] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)