### PR TITLE
Add a note to the README about actions/toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="#faq">FAQ</a>
 </p>
 
-<p align="center"><a href="https://npmjs.com/package/actions-toolkit"><img src="https://img.shields.io/npm/v/actions-toolkit/latest.svg" alt="NPM"></a> <a href="https://travis-ci.com/JasonEtco/actions-toolkit"><img src="https://badgen.now.sh/travis/JasonEtco/actions-toolkit" alt="Build Status"></a> <a href="https://codecov.io/gh/JasonEtco/actions-toolkit/"><img src="https://badgen.now.sh/codecov/c/github/JasonEtco/actions-toolkit" alt="Codecov"></a></p>
+<p align="center"><a href="https://npmjs.com/package/actions-toolkit"><img src="https://badgen.now.sh/npm/v/actions-toolkit" alt="NPM"></a> <a href="https://travis-ci.com/JasonEtco/actions-toolkit"><img src="https://badgen.now.sh/travis/JasonEtco/actions-toolkit" alt="Build Status"></a> <a href="https://codecov.io/gh/JasonEtco/actions-toolkit/"><img src="https://badgen.now.sh/codecov/c/github/JasonEtco/actions-toolkit" alt="Codecov"></a></p>
 
 **Heads up!** This toolkit was built to work with Actions v1. There is [an official toolkit](https://github.com/actions/toolkit) for [Actions v2](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/) that you should check out. This one _may_ work for v2, but is not guaranteed, and will likely be deprecated in the near future.
 


### PR DESCRIPTION
**Why?**

Now that [actions/toolkit](https://github.com/actions/toolkit), we should give folks links to the official toolkit to make sure they see it.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)