### PR TITLE
Wrap @actions/core and enable new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ This will create a new folder `my-cool-action` with the following files:
 * [Authenticated GitHub API client](#toolsgithub)
 * [Logging](#toolslog)
 * [Slash commands](#toolscommandcommand-args-match--promise)
-* [Parsing arguments](#toolsarguments)
 * [Reading files](#toolsgetfilepath-encoding--utf8)
 * [Run a CLI command](#toolsruninworkspacecommand-args-execaoptions)
 * [Pass information to another action](#toolsstore)
@@ -242,38 +241,6 @@ Run a CLI command in the workspace. This uses [execa](https://github.com/sindres
 
 ```js
 const result = await tools.runInWorkspace('npm', ['audit'])
-```
-
-<br>
-
-### tools.arguments
-
-An object of the parsed arguments passed to your action. This uses [`minimist`](https://github.com/substack/minimist) under the hood.
-
-When inputting arguments into your workflow file (like `main.workflow`) in an action as shown in the [Actions Docs](https://developer.github.com/actions/creating-workflows/workflow-configuration-options/#action-blocks), you can enter them as an array of strings or as a single string:
-
-```workflow
-args = ["container:release", "--app", "web"]
-# or
-args = "container:release --app web"
-```
-
-In `actions-toolkit`, `tools.arguments` will be an object:
-
-```js
-console.log(tools.arguments)
-// => { _: ['container:release'], app: 'web' }
-```
-
-There is currently a known bug with strings with multiple word arguments being parsed incorrectly. Arguments that contain strings with multiple words need to currently pass the arguments in an array:
-```workflow
-args = [ "To do", "100" ]
-```
-
-Or have a different [action entrypoint file](https://github.com/actions/npm/blob/master/entrypoint.sh):
-```
-#!/bin/sh
-sh -c "npm $*"
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This will create a new folder `my-cool-action` with the following files:
 * [The Toolkit class](#toolkit-options)
 * [Authenticated GitHub API client](#toolsgithub)
 * [Logging](#toolslog)
+* [Getting workflows' inputs](#toolsinputs)
 * [Slash commands](#toolscommandcommand-args-match--promise)
 * [Reading files](#toolsgetfilepath-encoding--utf8)
 * [Run a CLI command](#toolsruninworkspacecommand-args-execaoptions)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,25 @@ In the GitHub Actions output, this is the result:
 
 <br>
 
+### tools.inputs
+
+GitHub Actions workflows can define some "inputs" - options that can be passed to the action:
+
+```yaml
+uses: JasonEtco/example-action@master
+with:
+  foo: bar
+```
+
+You can access those using `tools.inputs`:
+
+```js
+console.log(tools.inputs) // -> { foo: 'bar' }
+console.log(tools.inputs.foo) // -> 'bar'
+```
+
+<br>
+
 ### tools.command(command, (args, match) => Promise<void>)
 
 Respond to a slash-command posted in a GitHub issue, comment, pull request, pull request review or commit comment. Arguments to the slash command are parsed by [minimist](https://github.com/substack/minimist). You can use a slash command in a larger comment, but the command must be at the start of the line:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ This will create a new folder `my-cool-action` with the following files:
 * [Parsing arguments](#toolsarguments)
 * [Reading files](#toolsgetfilepath-encoding--utf8)
 * [Run a CLI command](#toolsruninworkspacecommand-args-execaoptions)
-* [In-repo configuration](#toolsconfigfilename)
 * [Pass information to another action](#toolsstore)
 * [End the action's process](#toolsexit)
 * [Inspect the webhook event payload](#toolscontext)
@@ -194,25 +193,6 @@ await tools.command('deploy', () => { i++ })
 console.log(i)
 // -> 3
 ```
-
-<br>
-
-### tools.config(filename)
-
-Get the configuration settings for this action in the project workspace. This method can be used in three different ways:
-
-```js
-// Get the .rc file, parsed as JSON
-const cfg = tools.config('.myactionrc')
-
-// Get the YAML file, parsed as JSON
-const cfg = tools.config('myaction.yml')
-
-// Get the property in package.json
-const cfg = tools.config('myaction')
-```
-
-If the filename looks like `.myfilerc` it will look for that file. If it's a YAML file, it will parse that file as a JSON object. Otherwise, it will return the value of the property in the `package.json` file of the project.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ with:
 You can access those using `tools.inputs`:
 
 ```js
-console.log(tools.inputs) // -> { foo: 'bar' }
 console.log(tools.inputs.foo) // -> 'bar'
 ```
+
+_Note!_ This is not a plain object, it's an instance of [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), so be aware that there may be some differences.
 
 <br>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -960,12 +960,6 @@
         "pretty-format": "^25.1.0"
       }
     },
-    "@types/js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-0CFu/g4mDSNkodVwWijdlr8jH7RoplRWNgovjFLEZeT+QEbbZXjBmCe3HwaWheAlCbHwomTwzZoSedeOycABug==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -1188,6 +1182,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2107,7 +2102,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.1.0",
@@ -4481,6 +4477,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -6055,7 +6052,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg=="
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -969,7 +974,7 @@
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
@@ -6335,7 +6340,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     ]
   },
   "dependencies": {
+    "@actions/core": "^1.2.2",
     "@octokit/graphql": "^4.3.1",
     "@octokit/rest": "^16.43.1",
     "@types/flat-cache": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/JasonEtco/actions-toolkit#readme",
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "@types/js-yaml": "^3.12.2",
     "@types/node": "^13.7.4",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
@@ -62,7 +61,6 @@
     "enquirer": "^2.3.4",
     "execa": "^4.0.0",
     "flat-cache": "^2.0.1",
-    "js-yaml": "^3.13.1",
     "minimist": "^1.2.0",
     "signale": "^1.4.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import execa, { Options as ExecaOptions } from 'execa'
 import fs from 'fs'
-import yaml from 'js-yaml'
 import minimist, { ParsedArgs } from 'minimist'
 import path from 'path'
 import * as core from '@actions/core'
@@ -172,40 +171,6 @@ export class Toolkit<I extends InputType = InputType> {
     const pathToPackage = path.join(this.workspace, 'package.json')
     if (!fs.existsSync(pathToPackage)) throw new Error('package.json could not be found in your project\'s root.')
     return require(pathToPackage)
-  }
-
-  /**
-   * Get the configuration settings for this action in the project workspace.
-   *
-   * @param key - If this is a string like `.myfilerc` it will look for that file.
-   * If it's a YAML file, it will parse that file as a JSON object. Otherwise, it will
-   * return the value of the property in the `package.json` file of the project.
-   *
-   * @example This method can be used in three different ways:
-   *
-   * ```js
-   * // Get the .rc file
-   * const cfg = toolkit.config('.myactionrc')
-   *
-   * // Get the YAML file
-   * const cfg = toolkit.config('myaction.yml')
-   *
-   * // Get the property in package.json
-   * const cfg = toolkit.config('myaction')
-   * ```
-   */
-  public config <T = any> (key: string): T {
-    if (/\..+rc/.test(key)) {
-      // It's a file like .npmrc or .eslintrc!
-      return JSON.parse(this.getFile(key))
-    } else if (key.endsWith('.yml') || key.endsWith('.yaml')) {
-      // It's a YAML file! Gotta serialize it!
-      return yaml.safeLoad(this.getFile(key))
-    } else {
-      // It's a regular object key in the package.json
-      const pkg = this.getPackageJSON<any>()
-      return pkg[key]
-    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,11 +73,6 @@ export class Toolkit<I extends InputType = InputType> {
   public token: string
 
   /**
-   * An object of the parsed arguments passed to your action
-   */
-  public arguments: ParsedArgs
-
-  /**
    * An Octokit SDK client authenticated for this repository. See https://octokit.github.io/rest.js for the API.
    *
    * ```js
@@ -121,7 +116,6 @@ export class Toolkit<I extends InputType = InputType> {
     // Memoize environment variables and arguments
     this.workspace = process.env.GITHUB_WORKSPACE as string
     this.token = process.env.GITHUB_TOKEN as string
-    this.arguments = minimist(process.argv.slice(2))
 
     // Setup nested objects
     this.exit = new Exit(this.log)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
+import * as core from '@actions/core'
 import execa, { Options as ExecaOptions } from 'execa'
 import fs from 'fs'
 import minimist, { ParsedArgs } from 'minimist'
 import path from 'path'
-import * as core from '@actions/core'
 import { LoggerFunc, Signale } from 'signale'
 import { Context } from './context'
 import { Exit } from './exit'
 import { getBody } from './get-body'
 import { GitHub } from './github'
 import { Store } from './store'
+import { createInputProxy, InputType } from './inputs'
 
 export interface ToolkitOptions {
   /**
@@ -23,8 +24,6 @@ export interface ToolkitOptions {
   secrets?: string[],
   logger?: Signale
 }
-
-export interface InputType { [key: string]: string | undefined }
 
 export class Toolkit<I extends InputType = InputType> {
   /**
@@ -131,13 +130,7 @@ export class Toolkit<I extends InputType = InputType> {
     this.store = new Store(this.context.workflow, this.workspace)
 
     // Memoize our Proxy instance
-    this.inputs = new Proxy<I>({} as I, {
-      get (_, name: string) {
-        // When we attempt to get `inputs.___`, instead
-        // we call `core.getInput`.
-        return core.getInput(name)
-      }
-    })
+    this.inputs = createInputProxy<I>()
 
     // Check stuff
     this.checkAllowedEvents(this.opts.event)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import yaml from 'js-yaml'
 import minimist, { ParsedArgs } from 'minimist'
 import path from 'path'
+import * as core from '@actions/core'
 import { LoggerFunc, Signale } from 'signale'
 import { Context } from './context'
 import { Exit } from './exit'
@@ -49,6 +50,7 @@ export class Toolkit {
       // await that Promise before return the value, otherwise return as normal
       return ret instanceof Promise ? await ret : ret
     } catch (err) {
+      core.setFailed(err.message)
       tools.exit.failure(err)
     }
   }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,0 +1,27 @@
+import * as core from '@actions/core'
+
+export interface InputType { [key: string]: string | undefined }
+
+export function createInputProxy <I extends InputType = InputType>() {
+  return new Proxy<I>({} as I, {
+    get (_, name: string) {
+      // When we attempt to get `inputs.___`, instead
+      // we call `core.getInput`.
+      return core.getInput(name)
+    },
+    getOwnPropertyDescriptor() {
+      // We need to overwrite this to ensure that
+      // keys are enumerated
+      return {
+        enumerable: true,
+        configurable: true,
+        writable: false
+      }
+    },
+    ownKeys () {
+      const keys = Object.keys(process.env)
+      const filtered = keys.filter(key => key.startsWith('INPUT_'))
+      return filtered
+    }
+  })
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -182,23 +182,6 @@ describe('Toolkit', () => {
     })
   })
 
-  describe('#config', () => {
-    it('returns a property in the package.json', () => {
-      const actual = toolkit.config('action')
-      expect(actual).toEqual({ foo: true })
-    })
-
-    it('returns a parsed YAML file', () => {
-      const actual = toolkit.config('action.yml')
-      expect(actual).toEqual({ foo: true })
-    })
-
-    it('returns a .rc file as JSON', () => {
-      const actual = toolkit.config('.actionrc')
-      expect(actual).toEqual({ foo: true })
-    })
-  })
-
   describe('#runInWorkspace', () => {
     it('runs the command in the workspace', async () => {
       const result = await toolkit.runInWorkspace('echo', 'hello')

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -46,27 +46,6 @@ describe('Toolkit', () => {
     })
   })
 
-  describe('#inputs', () => {
-    beforeEach(() => {
-      process.env.INPUT_EXAMPLE = 'pizza'
-    })
-  
-    afterEach(() => {
-      delete process.env.INPUT_EXAMPLE
-    })
-  
-    it('returns the expected value', () => {
-      const result = toolkit.inputs.example
-      expect(result).toBe('pizza')
-    })
-  
-    it('accepts the correct types', () => {
-      const twolkit = new Toolkit<{ example: string }>()
-      const result = twolkit.inputs.example
-      expect(result).toBe('pizza')
-    })
-  })
-
   describe('#github', () => {
     it('returns a GitHub client', () => {
       expect(toolkit.github).toBeInstanceOf(Object)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -46,6 +46,27 @@ describe('Toolkit', () => {
     })
   })
 
+  describe('#inputs', () => {
+    beforeEach(() => {
+      process.env.INPUT_EXAMPLE = 'pizza'
+    })
+  
+    afterEach(() => {
+      delete process.env.INPUT_EXAMPLE
+    })
+  
+    it('returns the expected value', () => {
+      const result = toolkit.inputs.example
+      expect(result).toBe('pizza')
+    })
+  
+    it('accepts the correct types', () => {
+      const twolkit = new Toolkit<{ example: string }>()
+      const result = twolkit.inputs.example
+      expect(result).toBe('pizza')
+    })
+  })
+
   describe('#github', () => {
     it('returns a GitHub client', () => {
       expect(toolkit.github).toBeInstanceOf(Object)

--- a/tests/inputs.test.ts
+++ b/tests/inputs.test.ts
@@ -1,0 +1,42 @@
+import { createInputProxy, InputType } from "../src/inputs"
+
+describe('createInputProxy', () => {
+  let inputs: InputType
+
+  beforeEach(() => {
+    process.env.INPUT_EXAMPLE = 'pizza'
+    process.env.INPUT_FOO = 'bar'
+    inputs = createInputProxy()
+  })
+
+  afterEach(() => {
+    delete process.env.INPUT_EXAMPLE
+    delete process.env.INPUT_FOO
+  })
+
+  describe('#get', () => {
+    it('returns the expected value', () => {
+      const result = inputs.example
+      expect(result).toBe('pizza')
+    })
+  
+    it('accepts the correct types', () => {
+      inputs = createInputProxy<{ example: string }>()
+      const result = inputs.example
+      expect(result).toBe('pizza')
+    })
+  })
+
+  describe('#set', () => {
+    it('does not allow properties to be set', () => {
+      expect(() => inputs.test = 'test').toThrowError()
+    })
+  })
+
+  describe('#ownKeys', () => {
+    it('returns the filtered keys', () => {
+      const keys = Object.keys(inputs)
+      expect(keys).toEqual(['INPUT_EXAMPLE', 'INPUT_FOO'])
+    })
+  })
+})


### PR DESCRIPTION
**Why?**

[@actions/core](https://github.com/actions/toolkit) introduced a couple of new features that reach into the internals of the Actions runner, mostly by using [special commands](https://github.com/actions/toolkit/blob/master/docs/commands.md). I want this library to become a more opinionated wrapper around the official `@actions/*` libraries, so this PR implements a few features of those libraries as part of the `Toolkit` class.

**How?**

The main changes:

* `Toolkit.run` now calls `core.setFailed`, to create a failure annotation.
* `tools.inputs` is a new property - its an instance of [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/) that operates like an object of the action's inputs. This is the preferred way to get actions' consumers to pass options to the action.
  * Related, I've removed `Toolkit#config` and `tools.arguments`. These were built before the concept of inputs was available, and are now unnecessary. Open to adding them back, please open an issue if you'd like to see them!

☝️ Lots of breaking changes in there. This'll go into a 3.0.0 release.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)