### PR TITLE
Point to actions/checkout if getFile throws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -968,7 +968,7 @@
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
@@ -4792,7 +4792,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -6338,7 +6338,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "tsc --noEmit -p tests && jest --coverage && npm run lint",
     "test:update": "tsc --noEmit -p tests && jest --coverage -u && npm run lint",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export class Toolkit<I extends InputType = InputType> {
    */
   public getFile (filename: string, encoding = 'utf8') {
     const pathToFile = path.join(this.workspace, filename)
-    if (!fs.existsSync(pathToFile)) throw new Error(`File ${filename} could not be found in your project's workspace.`)
+    if (!fs.existsSync(pathToFile)) throw new Error(`File ${filename} could not be found in your project's workspace. You may need the actions/checkout action to clone the repository first.`)
     return fs.readFileSync(pathToFile, encoding)
   }
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Toolkit #getFile gets the contents of a file 1`] = `"I'm writing this o
 
 exports[`Toolkit #getFile gets the contents of a file with custom encoding 1`] = `"SSdtIHdyaXRpbmcgdGhpcyBvbiBhIHBsYW5lIOKciO+4jw=="`;
 
-exports[`Toolkit #getFile throws if the file could not be found 1`] = `"File DONTREADME.md could not be found in your project's workspace."`;
+exports[`Toolkit #getFile throws if the file could not be found 1`] = `"File DONTREADME.md could not be found in your project's workspace. You may need the actions/checkout action to clone the repository first."`;
 
 exports[`Toolkit #getPackageJSON returns the package.json file as a JSON object 1`] = `
 Object {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -13,7 +13,6 @@ describe('Toolkit', () => {
     // leaks on repeated calls in tests - used by Store.
     process.on = jest.fn()
 
-
     // Mock core.setFailed to a noop
     jest.spyOn(core, 'setFailed')
       .mockImplementationOnce(f => f)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import path from 'path'
+import * as core from '@actions/core'
 import { Signale } from 'signale'
 import { Toolkit } from '../src'
 import { NeutralCode } from '../src/exit'
@@ -11,6 +12,12 @@ describe('Toolkit', () => {
     // Mock the `process` event emitter to prevent memory
     // leaks on repeated calls in tests - used by Store.
     process.on = jest.fn()
+
+
+    // Mock core.setFailed to a noop
+    jest.spyOn(core, 'setFailed')
+      .mockImplementationOnce(f => f)
+
     toolkit = new Toolkit({ logger: new Signale({ disabled: true }) })
   })
 


### PR DESCRIPTION
**Why?**

This PR improves the error message thrown by `Toolkit#getFile`, because of confusion around needing to clone the repo via `actions/checkout`.

**How?**

Notes that you may need the `actions/checkout` action to clone the repository if the file cannot be found.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)