### PR TITLE
Support github_token input in addition to env.GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,18 @@ You can also make GraphQL requests:
 ```js
 const result = await tools.github.graphql(query, variables)
 ```
+
 See [https://github.com/octokit/graphql.js](https://github.com/octokit/graphql.js) for more details on how to leverage the GraphQL API.
+
+**Note:** To make this function, you must pass a GitHub API token to your action. You can do this in the workflow - both of these are automatically used if they exist:
+
+```yaml
+uses: your/action@v1
+with:
+  github_token: ${{ github.token }}
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
 
 <br>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,17 +126,19 @@ export class Toolkit<I extends InputType = InputType, O extends OutputType = Out
 
     // Memoize environment variables and arguments
     this.workspace = process.env.GITHUB_WORKSPACE as string
-    this.token = opts.token || process.env.GITHUB_TOKEN as string
+
+    // Memoize our Proxy instance
+    this.inputs = createInputProxy<I>()
+    this.outputs = createOutputProxy<O>()
+
+    // Memoize the GitHub API token
+    this.token = opts.token || this.inputs.github_token || process.env.GITHUB_TOKEN as string
 
     // Setup nested objects
     this.exit = new Exit(this.log)
     this.context = new Context()
     this.github = new Octokit({ auth: `token ${this.token}` })
     this.store = new Store(this.context.workflow, this.workspace)
-
-    // Memoize our Proxy instance
-    this.inputs = createInputProxy<I>()
-    this.outputs = createOutputProxy<O>()
 
     // Check stuff
     this.checkAllowedEvents(this.opts.event)


### PR DESCRIPTION
**Why?**

A lot of actions prefer to use inputs over environment variables. They're documented in the `action.yml` file, and you can easily fill in default/required values.

**How?**

This PR changes `Toolkit.token` to consider `inputs.github_token` before falling back to `env.GITHUB_TOKEN`. To be safe, I'm going to make this change a part of `v5`, since it could be breaking for workflows that use `github_token` for other things.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)