### PR TITLE
Remove duplicate "background color" in CLI

### DIFF
--- a/bin/create-action.js
+++ b/bin/create-action.js
@@ -73,7 +73,7 @@ async function getActionMetadata () {
     {
       type: 'autocomplete',
       name: 'color',
-      message: 'Choose a background color background color used in the visual workflow editor for your action.',
+      message: 'Choose a background color used in the visual workflow editor for your action.',
       choices: colors
     }
   ])


### PR DESCRIPTION
**Why?**

The words `background color` are used twice in a row in `bin/create-action.js`

**How?**

Removed duplicate words

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)