### PR TITLE
fix: return never from exit functions

### DIFF
--- a/src/exit.ts
+++ b/src/exit.ts
@@ -23,7 +23,7 @@ export class Exit {
   /**
    * Stop the action with a "success" status
    */
-  public success (message?: string) {
+  public success (message?: string): never {
     if (message) this.logger.success(message)
     process.exit(SuccessCode)
   }
@@ -31,7 +31,7 @@ export class Exit {
   /**
    * Stop the action with a "neutral" status
    */
-  public neutral (message?: string) {
+  public neutral (message?: string): never {
     if (message) this.logger.info(message)
     process.exit(NeutralCode)
   }
@@ -39,7 +39,7 @@ export class Exit {
   /**
    * Stop the action with a "failed" status
    */
-  public failure (message?: string) {
+  public failure (message?: string): never {
     if (message) this.logger.fatal(message)
     process.exit(FailureCode)
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -37,7 +37,7 @@ describe('Toolkit', () => {
 
     it('logs and fails when the function throws an error', async () => {
       const err = new Error('Whoops!')
-      const exitFailure = jest.fn()
+      const exitFailure = jest.fn<never, any>()
 
       await Toolkit.run(async twolkit => {
         twolkit.exit.failure = exitFailure


### PR DESCRIPTION
**Why?**

This should help in Typescript control flow analysis.