### PR TITLE
Improve types for context.issue/pull_request

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -73,41 +73,41 @@ export class Context {
   public get issue () {
     const payload = this.payload
 
-    const data: { [k: string]: any } = {
-      ...this.repo
-    }
-
+    let issue_number: number
     if (payload.issue) {
       // If it's an issue
-      data.issue_number = payload.issue.number
+      issue_number = payload.issue.number
     } else if (payload.pull_request) {
       // If it's a PR
-      data.issue_number = payload.pull_request.number
+      issue_number = payload.pull_request.number
     } else if (payload.number) {
       // Just sittin' there on the payload
-      data.issue_number = payload.number
+      issue_number = payload.number
     } else {
       throw new Error('tools.context.issue cannot be used with this event, there is no issue or pull_request object.')
     }
 
-    return data
+    return {
+      ...this.repo,
+      issue_number
+    }
   }
 
   public get pullRequest () {
     const payload = this.payload
 
-    const data: { [k: string]: any } = {
-      ...this.repo
-    }
-
+    let pull_number: number
     if (payload.pull_request) {
       // If it's a PR, the API expects pull_number
-      data.pull_number = payload.pull_request.number
+      pull_number = payload.pull_request.number
     } else {
       throw new Error('tools.context.pullRequest cannot be used with this event, there is no pull_request object.')
     }
 
-    return data
+    return {
+      ...this.repo,
+      pull_number
+    }
   }
 
   public get repo () {


### PR DESCRIPTION
**Why?**

Noticed these types were unhelpful - before, it was returning `{ [key: string]: any }`, because of how we defined `data`.

**How?**

Now we only conditionally define the `issue_number` or `pull_number`, and return a more strict object that includes `context.repo`, so the typing is more specific.

---

- [x] Tests have been added/updated (if necessary)
- [x] Documentation has been updated (if necessary)