### PR TITLE
Require @actions/core 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ]
   },
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@octokit/rest": "^17.9.0",
     "@types/flat-cache": "^2.0.0",


### PR DESCRIPTION
**Why?**

[GitHub disclosed a security vulnerability in GitHub Actions](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) around `set-env` and `add-path`.

> Action authors who are using the toolkit should update the @actions/core package to v1.2.6 or greater to get the updated addPath and exportVariable functions.

**How?**

This pull request updates the `@actions/core` dependency version to `^1.2.6`, instead of `^1.2.4`, to ensure version `1.2.6` or greater is installed.

`package-lock.json` already has version `1.2.6`.

---

- [ ] Tests have been added/updated (if necessary)
- [ ] Documentation has been updated (if necessary)